### PR TITLE
Render help block in right place on horizontal form

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -52,10 +52,10 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow{
 		//Render element
 		$sElementContent = $this->renderElement($oElement).
 		//Render errors
-		$this->renderErrors($oElement).
+		$this->renderErrors($oElement);
 		//Render help block
 		if($sLayout !== \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_HORIZONTAL) {
-			$this->renderHelpBlock($oElement);
+			$sElementContent .= $this->renderHelpBlock($oElement);
 		}
 
 		//Render form row


### PR DESCRIPTION
On the horizontal layout the `help-block` is rendered outside of the div containing the actual element. This causes the `help-block` to be aligned with the far left of the form which looks weird. This PR makes it so the `help-block` gets rendered inside the div that contains the element, making it line up with the form element.
