### PR TITLE
Configure tagName to label

### DIFF
--- a/src/TwbBundle/View/Helper/TwbBundleLabel.php
+++ b/src/TwbBundle/View/Helper/TwbBundleLabel.php
@@ -4,7 +4,19 @@ class TwbBundleLabel extends \Zend\Form\View\Helper\AbstractHelper{
 	/**
 	 * @var string
 	 */
-	private static $labelFormat = '<span %s>%s</span>';
+	private static $labelFormat = '<%s %s>%s</span>';
+
+    /**
+     * @var string
+     */
+    protected $tagName = 'span';
+
+    /**
+     * @var array
+     */
+    protected $validTagAttributes = array(
+        'href' => true,
+    );
 
 	/**
 	 * Invoke helper as functor, proxies to {@link render()}.
@@ -37,6 +49,7 @@ class TwbBundleLabel extends \Zend\Form\View\Helper\AbstractHelper{
 		if(null !== ($oTranslator = $this->getTranslator()))$sLabelMessage = $oTranslator->translate($sLabelMessage, $this->getTranslatorTextDomain());
 		return sprintf(
 			self::$labelFormat,
+            isset($aLabelAttributes['tagName'])?$aLabelAttributes['tagName']:$this->tagName,
 			$this->createAttributesString($aLabelAttributes),
 			$sLabelMessage
 		);


### PR DESCRIPTION
Hi,

As you can see in https://github.com/twbs/bootstrap/blob/master/dist/css/bootstrap.css#L4135
It's possible to use label with href attribute, so I added possiblity to change default tagName, you should use like that:

``` php
$this->label('Removed', array('tagName' => 'a', 'href' => '/home/removed'));
```
