### PR TITLE
Whatever if has label or not, you should render the same way

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -126,7 +126,8 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow
                 if ($sLayout !== \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_HORIZONTAL) return $this->getElementHelper()->render($oElement);
             }
             //Button element is a special case, because label is always rendered inside it
-            elseif (!$oElement instanceof \Zend\Form\Element\Button) {
+            elseif ($oElement instanceof \Zend\Form\Element\Button) $sLabelContent = '';
+            else {
                 $aLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
 
                 //Validation state


### PR DESCRIPTION
With form-horizontal and column-size setted, if it has label you render like that

``` html
<div class="form-group">
    <label class="col-md-2" ...></label>
    <div class="col-md-10">
        <input .../>
    </div>
</div>
```

If it hasn't label you render like that

``` html
<div class="form-group col-md-12">
    <input .../>
</div>
```

And this pull request fix that, always render like the first example
The fixes is some spacing
