### PR TITLE
Update visibility

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
@@ -6,13 +6,13 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
     /**
      * @var string
      */
-    private static $addonFormat = '<%s class="%s">%s</%s>';
+    protected static $addonFormat = '<%s class="%s">%s</%s>';
 
 
     /**
      * @var string
      */
-    private static $inputGroupFormat = '<div class="input-group %s">%s</div>';
+    protected static $inputGroupFormat = '<div class="input-group %s">%s</div>';
 
     /**
      * Translator (optional)


### PR DESCRIPTION
When I overwrite `TwbBundle\Form\View\Helper\TwbBundleFormElement` I can't access `$addonFormat` and `$inputGroupFormat`
