### PR TITLE
Allow for a blank message to be sent to the alert helper

### DIFF
--- a/src/TwbBundle/View/Helper/TwbBundleAlert.php
+++ b/src/TwbBundle/View/Helper/TwbBundleAlert.php
@@ -20,7 +20,7 @@ class TwbBundleAlert extends \Zend\Form\View\Helper\AbstractHelper{
 	 */
 	public function __invoke($sAlertMessage = null, $aAlertAttributes = null, $bDismissable = false){
 		if($sAlertMessage === null) return $this;
-		if($sAlertMessage == '') return '';
+		if($sAlertMessage === '' || $sAlertMessage === false) return '';
 		return $this->render($sAlertMessage,$aAlertAttributes,$bDismissable);
 	}
 


### PR DESCRIPTION
This is useful if you are doing something like

```
echo $this->alert($this->flashMessenger()->render(), array('class' => 'alert-danger'), true);
```

`$this->flashMessenger()` already has a short circuit that returns a blank string is there are no messages. This will also allow for the alert message to be a numeric zero.
