### PR TITLE
Fix missing possibility of assigning a CSS-class

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormElementErrors.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormElementErrors.php
@@ -1,7 +1,7 @@
 <?php
 namespace TwbBundle\Form\View\Helper;
 class TwbBundleFormElementErrors extends \Zend\Form\View\Helper\FormElementErrors{
-	protected $messageOpenFormat = '<ul class="help-block"><li>';
-	protected $messageCloseString = '</li></ul>';
-	protected $messageSeparatorString = '</li><li>';
+    protected $attributes = array(
+        'class' => 'help-block'
+    );
 }


### PR DESCRIPTION
Due to the missing pattern "%s" in the property

``` php
  protected $messageOpenFormat = '<ul%s><li>';
```

it was not possible to set a class in ViewScript via

``` php
  $this->formElementErrors()->setAttributes(array('class' => 'my-errorlist-class'));
```

Now the behaviour is still: You do nothing the default value for css-class "help-block" is kept, but if you want to you are able to set/add own css-classes.
