### PR TITLE
Fixes ->form()->openTag($form) usage

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
@@ -1,15 +1,23 @@
 <?php
 namespace TwbBundle\Form\View\Helper;
+
 class TwbBundleForm extends \Zend\Form\View\Helper\Form
 {
     const LAYOUT_HORIZONTAL = 'horizontal';
-	const LAYOUT_INLINE = 'inline';
-	const LAYOUT_SEARCH = 'search';
+    const LAYOUT_INLINE = 'inline';
+    const LAYOUT_SEARCH = 'search';
 
-	/**
-	 * @var string
-	 */
-	private static $formRowFormat = '<div class="row">%s</div>';
+    /**
+     * @var string
+     */
+    private static $formRowFormat = '<div class="row">%s</div>';
+
+    /**
+     * Form layout (see LAYOUT_* consts)
+     *
+     * @var string
+     */
+    protected $formLayout = null;
 
     /**
      * @see \Zend\Form\View\Helper\Form::__invoke()
@@ -22,6 +30,7 @@ class TwbBundleForm extends \Zend\Form\View\Helper\Form
         if ($oForm) {
             return $this->render($oForm, $sFormLayout);
         }
+        $this->formLayout = $sFormLayout;
         return $this;
 	}
 
@@ -32,25 +41,14 @@ class TwbBundleForm extends \Zend\Form\View\Helper\Form
      * @param string $sFormLayout
      * @return string
      */
-    public function render(\Zend\Form\FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL){
-
+    public function render(\Zend\Form\FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL)
+    {
     	//Prepare form if needed
     	if (method_exists($oForm, 'prepare')) {
     		$oForm->prepare();
     	}
 
-    	//Set form layout class
-    	if(is_string($sFormLayout)){
-    		$sLayoutClass = 'form-'.$sFormLayout;
-    		if ($sFormClass = $oForm->getAttribute('class')) {
-                if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sFormClass)) {
-                    $oForm->setAttribute('class', trim($sFormClass . ' ' . $sLayoutClass));
-                }
-            }
-            else {
-                $oForm->setAttribute('class', $sLayoutClass);
-            }
-        }
+    	$this->setFormClass($oForm, $sFormLayout);
 
     	//Set form role
     	if (!$oForm->getAttribute('role')) {
@@ -76,5 +74,39 @@ class TwbBundleForm extends \Zend\Form\View\Helper\Form
             $sFormContent = sprintf(self::$formRowFormat, $sFormContent);
         }
         return $this->openTag($oForm).$sFormContent.$this->closeTag();
+    }
+
+    /**
+     * Sets form layout class
+     *
+     * @param \Zend\Form\FormInterface $oForm
+     * @param string $sFormLayout
+     * @return void
+     */
+    protected function setFormClass(\Zend\Form\FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL)
+    {
+        if(is_string($sFormLayout)){
+            $sLayoutClass = 'form-'.$sFormLayout;
+            if ($sFormClass = $oForm->getAttribute('class')) {
+                if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sFormClass)) {
+                    $oForm->setAttribute('class', trim($sFormClass . ' ' . $sLayoutClass));
+                }
+            }
+            else {
+                $oForm->setAttribute('class', $sLayoutClass);
+            }
+        }
+    }
+
+    /**
+     * Generate an opening form tag
+     *
+     * @param  null|\Zend\Form\FormInterface $form
+     * @return string
+     */
+    public function openTag(\Zend\Form\FormInterface $form = null)
+    {
+        $this->setFormClass($form, $this->formLayout);
+        return parent::openTag($form);
     }
 }


### PR DESCRIPTION
Makes it possible to use ->openTag to render the form using correct layout classes.

Examples:

```
<?php echo $this->form()->openTag($this->customerForm); ?>
<?php echo $this->form(null, 'inline')->openTag($this->customerForm); ?>
```
