### PR TITLE
Allow label escape disabling like native Zend\Form\View\Helper\FormRow

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -180,7 +180,13 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
 
                 $sLabelOpen = $oLabelHelper->openTag($oElement->getAttribute('id') ? $oElement : $aLabelAttributes);
                 $sLabelClose = $oLabelHelper->closeTag();
-                $sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
+                
+                // Allow label html escape desable
+                //$sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
+                
+                if (! $oElement instanceof \Zend\Form\LabelAwareInterface || ! $oElement->getLabelOption('disable_html_escape')) {
+                	$sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
+                }
             }
         }
 


### PR DESCRIPTION
This code modification allow user to disable the label html escape with the label options. For example : 

$form->add(array(
                'type' => 'Zend\Form\Element\Text',
                'name' => 'element',
                'options' => array(
                        'label' => 'Element <span>Label</span> :',
                        'label_options' => array('disable_html_escape' => true)
                )
        ));
