### PR TITLE
Provide a way of ignore custom view helpers, plus update coding style

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,8 +1,25 @@
 <?php
 
 return array(
-    'view_helpers' => array(
-        'invokables' => array(
+    'twbbundle' => array (
+        'ignoredViewHelpers' => array (
+            'file',
+            'checkbox',
+            'radio',
+            'submit',
+            'multi_checkbox',
+            'static',
+            'button',
+            'reset'
+        )
+    ),
+    'service_manager' => array (
+        'factories' => array (
+            'TwbBundle\Options\ModuleOptions' => 'TwbBundle\Options\Factory\ModuleOptionsFactory'
+        )
+    ),
+    'view_helpers' => array (
+        'invokables' => array (
             //Alert
             'alert' => 'TwbBundle\View\Helper\TwbBundleAlert',
             //Badge
@@ -17,7 +34,6 @@ return array(
             'formSubmit' => 'TwbBundle\Form\View\Helper\TwbBundleFormButton',
             'formCheckbox' => 'TwbBundle\Form\View\Helper\TwbBundleFormCheckbox',
             'formCollection' => 'TwbBundle\Form\View\Helper\TwbBundleFormCollection',
-            'formElement' => 'TwbBundle\Form\View\Helper\TwbBundleFormElement',
             'formElementErrors' => 'TwbBundle\Form\View\Helper\TwbBundleFormElementErrors',
             'formMultiCheckbox' => 'TwbBundle\Form\View\Helper\TwbBundleFormMultiCheckbox',
             'formRadio' => 'TwbBundle\Form\View\Helper\TwbBundleFormRadio',
@@ -31,6 +47,9 @@ return array(
             'fontAwesome' => 'TwbBundle\View\Helper\TwbBundleFontAwesome',
             //Label
             'label' => 'TwbBundle\View\Helper\TwbBundleLabel'
+        ),
+        'factories' => array (
+            'formElement' => 'TwbBundle\Form\View\Helper\Factory\TwbBundleFormElementFactory',
         )
-    )
+    ),
 );

--- a/src/TwbBundle/Form/View/Helper/Factory/TwbBundleFormElementFactory.php
+++ b/src/TwbBundle/Form/View/Helper/Factory/TwbBundleFormElementFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TwbBundle\Form\View\Helper\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use TwbBundle\Form\View\Helper\TwbBundleFormElement;
+
+/**
+ * Factory to inject the ModuleOptions hard dependency
+ *
+ * @author Fábio Carneiro <fahecs@gmail.com>
+ * @license MIT
+ */
+class TwbBundleFormElementFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $options = $serviceLocator->getServiceLocator()->get('TwbBundle\Options\ModuleOptions');
+        return new TwbBundleFormElement($options);
+    }
+}

--- a/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
@@ -1,7 +1,11 @@
 <?php
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleForm extends \Zend\Form\View\Helper\Form
+use Zend\Form\View\Helper\Form;
+use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
+
+class TwbBundleForm extends Form
 {
     const LAYOUT_HORIZONTAL = 'horizontal';
     const LAYOUT_INLINE = 'inline';
@@ -19,79 +23,78 @@ class TwbBundleForm extends \Zend\Form\View\Helper\Form
     protected $formLayout = null;
 
     /**
-     * @see \Zend\Form\View\Helper\Form::__invoke()
-     * @param \Zend\Form\FormInterface $oForm
+     * @see Form::__invoke()
+     * @param FormInterface $oForm
      * @param string $sFormLayout
-     * @return \TwbBundle\Form\View\Helper\TwbBundleForm|string
+     * @return TwbBundleForm|string
      */
-    public function __invoke(\Zend\Form\FormInterface $oForm = null, $sFormLayout = self::LAYOUT_HORIZONTAL)
+    public function __invoke(FormInterface $oForm = null, $sFormLayout = self::LAYOUT_HORIZONTAL)
     {
         if ($oForm) {
             return $this->render($oForm, $sFormLayout);
         }
         $this->formLayout = $sFormLayout;
         return $this;
-	}
+    }
 
     /**
      * Render a form from the provided $oForm,
-     * @see \Zend\Form\View\Helper\Form::render()
-     * @param \Zend\Form\FormInterface $oForm
+     * @see Form::render()
+     * @param FormInterface $oForm
      * @param string $sFormLayout
      * @return string
      */
-    public function render(\Zend\Form\FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL)
+    public function render(FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL)
     {
-    	//Prepare form if needed
-    	if (method_exists($oForm, 'prepare')) {
-    		$oForm->prepare();
-    	}
+        //Prepare form if needed
+        if (method_exists($oForm, 'prepare')) {
+            $oForm->prepare();
+        }
 
-    	$this->setFormClass($oForm, $sFormLayout);
+        $this->setFormClass($oForm, $sFormLayout);
 
-    	//Set form role
-    	if (!$oForm->getAttribute('role')) {
+        //Set form role
+        if (!$oForm->getAttribute('role')) {
             $oForm->setAttribute('role', 'form');
         }
 
         $bHasColumnSizes = false;
-       	$sFormContent = '';
-       	$oRenderer = $this->getView();
-       	foreach($oForm as $oElement){
-    		$aOptions = $oElement->getOptions();
-    		if (!$bHasColumnSizes && !empty($aOptions['column-size'])) {
+        $sFormContent = '';
+        $oRenderer = $this->getView();
+        foreach ($oForm as $oElement) {
+            $aOptions = $oElement->getOptions();
+            if (!$bHasColumnSizes && !empty($aOptions['column-size'])) {
                 $bHasColumnSizes = true;
             }
             //Define layout option to form elements if not already defined
-    		if($sFormLayout && empty($aOptions['twb-layout'])){
+            if ($sFormLayout && empty($aOptions['twb-layout'])) {
                 $aOptions['twb-layout'] = $sFormLayout;
-	    		$oElement->setOptions($aOptions);
-    		}
-    		$sFormContent .= $oElement instanceof \Zend\Form\FieldsetInterface?$oRenderer->formCollection($oElement):$oRenderer->formRow($oElement);
-    	}
-    	if ($bHasColumnSizes && $sFormLayout !== self::LAYOUT_HORIZONTAL) {
+                $oElement->setOptions($aOptions);
+            }
+            $sFormContent .= $oElement instanceof FieldsetInterface ? $oRenderer->formCollection($oElement) : $oRenderer->formRow($oElement);
+        }
+        if ($bHasColumnSizes && $sFormLayout !== self::LAYOUT_HORIZONTAL) {
             $sFormContent = sprintf(self::$formRowFormat, $sFormContent);
         }
-        return $this->openTag($oForm).$sFormContent.$this->closeTag();
+        return $this->openTag($oForm) . $sFormContent . $this->closeTag();
     }
 
     /**
      * Sets form layout class
      *
-     * @param \Zend\Form\FormInterface $oForm
+     * @param FormInterface $oForm
      * @param string $sFormLayout
      * @return void
      */
-    protected function setFormClass(\Zend\Form\FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL)
+    protected function setFormClass(FormInterface $oForm, $sFormLayout = self::LAYOUT_HORIZONTAL)
     {
-        if(is_string($sFormLayout)){
+        if (is_string($sFormLayout)) {
             $sLayoutClass = 'form-'.$sFormLayout;
             if ($sFormClass = $oForm->getAttribute('class')) {
                 if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sFormClass)) {
                     $oForm->setAttribute('class', trim($sFormClass . ' ' . $sLayoutClass));
                 }
-            }
-            else {
+            } else {
                 $oForm->setAttribute('class', $sLayoutClass);
             }
         }
@@ -100,10 +103,10 @@ class TwbBundleForm extends \Zend\Form\View\Helper\Form
     /**
      * Generate an opening form tag
      *
-     * @param  null|\Zend\Form\FormInterface $form
+     * @param  null|FormInterface $form
      * @return string
      */
-    public function openTag(\Zend\Form\FormInterface $form = null)
+    public function openTag(FormInterface $form = null)
     {
         $this->setFormClass($form, $this->formLayout);
         return parent::openTag($form);

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormCheckbox.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormCheckbox.php
@@ -2,34 +2,46 @@
 
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleFormCheckbox extends \Zend\Form\View\Helper\FormCheckbox {
+use Zend\Form\View\Helper\FormRow;
+use Zend\Form\View\Helper\FormCheckbox;
+use Zend\Form\ElementInterface;
+use InvalidArgumentException;
+use LogicException;
+use Zend\Form\Element\Checkbox;
+use Zend\Form\View\Helper\FormLabel;
+
+class TwbBundleFormCheckbox extends FormCheckbox
+{
 
     /**
      * Form label helper instance
-     * @var \Zend\Form\View\Helper\FormLabel
+     * @var FormLabel
      */
     protected $labelHelper;
 
     /**
-     * @see \Zend\Form\View\Helper\FormCheckbox::render()
-     * @param \Zend\Form\ElementInterface $oElement
-     * @throws \LogicException
-     * @throws \InvalidArgumentException
+     * @see FormCheckbox::render()
+     * @param ElementInterface $oElement
+     * @throws LogicException
+     * @throws InvalidArgumentException
      * @return string
      */
-    public function render(\Zend\Form\ElementInterface $oElement) {
+    public function render(ElementInterface $oElement)
+    {
         if ($oElement->getOption('disable-twb')) {
             return parent::render($oElement);
         }
 
-        if (!$oElement instanceof \Zend\Form\Element\Checkbox) {
-            throw new \InvalidArgumentException(sprintf(
-                    '%s requires that the element is of type Zend\Form\Element\Checkbox', __METHOD__
+        if (!$oElement instanceof Checkbox) {
+            throw new InvalidArgumentException(sprintf(
+                '%s requires that the element is of type Zend\Form\Element\Checkbox',
+                __METHOD__
             ));
         }
         if (($sName = $oElement->getName()) !== 0 && empty($sName)) {
-            throw new \LogicException(sprintf(
-                    '%s requires that the element has an assigned name; none discovered', __METHOD__
+            throw new LogicException(sprintf(
+                '%s requires that the element has an assigned name; none discovered',
+                __METHOD__
             ));
         }
 
@@ -61,20 +73,28 @@ class TwbBundleFormCheckbox extends \Zend\Form\View\Helper\FormCheckbox {
         $sElementContent = sprintf('<input %s%s', $this->createAttributesString($aAttributes), $sClosingBracket);
 
         //Add label markup
-        if ($this->getLabelPosition($oElement) === \Zend\Form\View\Helper\FormRow::LABEL_PREPEND) {
-            $sElementContent = $sLabelOpen . ($sLabelContent ? rtrim($sLabelContent) . ' ' : '') . $sElementContent . $sLabelClose;
+        if ($this->getLabelPosition($oElement) === FormRow::LABEL_PREPEND) {
+            $sElementContent = $sLabelOpen .
+                ($sLabelContent ? rtrim($sLabelContent) . ' ' : '') .
+                $sElementContent .
+                $sLabelClose;
         } else {
-            $sElementContent = $sLabelOpen . $sElementContent . ($sLabelContent ? ' ' . ltrim($sLabelContent) : '') . $sLabelClose;
+            $sElementContent = $sLabelOpen .
+                $sElementContent .
+                ($sLabelContent ? ' ' . ltrim($sLabelContent) : '') .
+                $sLabelClose;
         }
 
         //Render hidden input
         if ($oElement->useHiddenElement()) {
             $sElementContent = sprintf(
-                            '<input type="hidden" %s%s', $this->createAttributesString(array(
-                                'name' => $aAttributes['name'],
-                                'value' => $oElement->getUncheckedValue(),
-                            )), $sClosingBracket
-                    ) . $sElementContent;
+                '<input type="hidden" %s%s',
+                $this->createAttributesString(array(
+                    'name' => $aAttributes['name'],
+                    'value' => $oElement->getUncheckedValue(),
+                )),
+                $sClosingBracket
+            ) . $sElementContent;
         }
         return $sElementContent;
     }
@@ -83,28 +103,29 @@ class TwbBundleFormCheckbox extends \Zend\Form\View\Helper\FormCheckbox {
      * Get the label position
      * @return string
      */
-    public function getLabelPosition(\Zend\Form\Element\Checkbox $oElement) {
-        return $oElement->getLabelOption('position')? : \Zend\Form\View\Helper\FormRow::LABEL_APPEND;
+    public function getLabelPosition(Checkbox $oElement)
+    {
+        return $oElement->getLabelOption('position')? : FormRow::LABEL_APPEND;
     }
 
     /**
      * Retrieve the FormLabel helper
-     * @return \Zend\Form\View\Helper\FormLabel
+     * @return FormLabel
      */
-    protected function getLabelHelper() {
+    protected function getLabelHelper()
+    {
         if ($this->labelHelper) {
             return $this->labelHelper;
         }
         if (method_exists($this->view, 'plugin')) {
             $this->labelHelper = $this->view->plugin('form_label');
         }
-        if (!($this->labelHelper instanceof \Zend\Form\View\Helper\FormLabel)) {
-            $this->labelHelper = new \Zend\Form\View\Helper\FormLabel();
+        if (!($this->labelHelper instanceof FormLabel)) {
+            $this->labelHelper = new FormLabel();
         }
         if ($this->hasTranslator()) {
             $this->labelHelper->setTranslator($this->getTranslator(), $this->getTranslatorTextDomain());
         }
         return $this->labelHelper;
     }
-
 }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormCollection.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormCollection.php
@@ -3,9 +3,11 @@
 namespace TwbBundle\Form\View\Helper;
 
 use Zend\Form\Element\Collection as CollectionElement;
+use Zend\Form\View\Helper\FormCollection;
+use Zend\Form\ElementInterface;
 
-class TwbBundleFormCollection extends \Zend\Form\View\Helper\FormCollection {
-
+class TwbBundleFormCollection extends FormCollection
+{
     /**
      * @var string
      */
@@ -29,7 +31,8 @@ class TwbBundleFormCollection extends \Zend\Form\View\Helper\FormCollection {
      * @param \Zend\Form\ElementInterface $oElement
      * @return string
      */
-    public function render(\Zend\Form\ElementInterface $oElement) {
+    public function render(ElementInterface $oElement)
+    {
         $oRenderer = $this->getView();
         if (!method_exists($oRenderer, 'plugin')) {
             return '';
@@ -68,8 +71,8 @@ class TwbBundleFormCollection extends \Zend\Form\View\Helper\FormCollection {
                 }
 
                 $sMarkup = sprintf(
-                                self::$legendFormat, ($sAttributes = $this->createAttributesString($oElement->getLabelAttributes()? : array())) ? ' ' . $sAttributes : '', $this->getEscapeHtmlHelper()->__invoke($sLabel)
-                        ) . $sMarkup;
+                        self::$legendFormat, ($sAttributes = $this->createAttributesString($oElement->getLabelAttributes()? : array())) ? ' ' . $sAttributes : '', $this->getEscapeHtmlHelper()->__invoke($sLabel)
+                ) . $sMarkup;
             }
 
             //Set form layout class
@@ -99,7 +102,7 @@ class TwbBundleFormCollection extends \Zend\Form\View\Helper\FormCollection {
      */
     public function renderTemplate(CollectionElement $collection)
     {
-        if($sElementLayout = $collection->getOption('twb-layout')) {
+        if ($sElementLayout = $collection->getOption('twb-layout')) {
             $elementOrFieldset = $collection->getTemplateElement();
             $elementOrFieldset->setOption('twb-layout', $sElementLayout);
         }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
@@ -2,8 +2,21 @@
 
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements \Zend\I18n\Translator\TranslatorAwareInterface {
+use Traversable;
+use InvalidArgumentException;
+use LogicException;
+use Zend\Form\ElementInterface;
+use Zend\Form\View\Helper\FormElement;
+use Zend\Form\Element\Collection;
+use Zend\Form\Factory;
+use Zend\I18n\Translator\TranslatorAwareInterface;
+use Zend\I18n\Translator\TranslatorInterface;
+use Zend\I18n\Translator\Translator;
+use TwbBundle\Options\ModuleOptions;
+use Zend\Form\Element\Button;
 
+class TwbBundleFormElement extends FormElement implements TranslatorAwareInterface
+{
     /**
      * @var string
      */
@@ -16,7 +29,7 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
 
     /**
      * Translator (optional)
-     * @var \Zend\I18n\Translator\Translator
+     * @var Translator
      */
     protected $translator;
 
@@ -31,6 +44,12 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
      * @var boolean
      */
     protected $translatorEnabled = true;
+    
+    /**
+     * Hold configurable options
+     * @var ModuleOptions 
+     */
+    protected $options;
 
     /**
      * Instance map to view helper
@@ -47,17 +66,23 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
         'Zend\Form\Element\MonthSelect' => 'formmonthselect',
         'TwbBundle\Form\Element\StaticElement' => 'formStatic',
     );
+    
+    public function __construct(ModuleOptions $options)
+    {
+        $this->options = $options;
+    }
 
     /**
      * Render an element
-     * @param \Zend\Form\ElementInterface $oElement
+     * @param ElementInterface $oElement
      * @return string
      */
-    public function render(\Zend\Form\ElementInterface $oElement) {
+    public function render(ElementInterface $oElement)
+    {
         // Add form-controll class
         $sElementType = $oElement->getAttribute('type');
-        if (
-                !in_array($sElementType, array('file', 'checkbox', 'radio', 'submit', 'multi_checkbox', 'static', 'button', 'reset')) && !($oElement instanceof \Zend\Form\Element\Collection)
+        if (!in_array($sElementType, $this->options->getIgnoredViewHelpers()) &&
+            !($oElement instanceof Collection)
         ) {
             if ($sElementClass = $oElement->getAttribute('class')) {
                 if (!preg_match('/(\s|^)form-control(\s|$)/', $sElementClass)) {
@@ -91,7 +116,9 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
                 }
             }
             return sprintf(
-                    self::$inputGroupFormat, trim($sSpecialClass), $sMarkup
+                self::$inputGroupFormat,
+                trim($sSpecialClass),
+                $sMarkup
             );
         }
         return $sMarkup;
@@ -100,20 +127,24 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
     /**
      * Render addo-on markup
      * @param string $aAddOnOptions
-     * @throws \InvalidArgumentException
-     * @throws \LogicException
+     * @throws InvalidArgumentException
+     * @throws LogicException
      * @return string
      */
-    protected function renderAddOn($aAddOnOptions) {
+    protected function renderAddOn($aAddOnOptions)
+    {
         if (empty($aAddOnOptions)) {
-            throw new \InvalidArgumentException('Addon options are empty');
+            throw new InvalidArgumentException('Addon options are empty');
         }
-        if ($aAddOnOptions instanceof \Zend\Form\ElementInterface) {
+        if ($aAddOnOptions instanceof ElementInterface) {
             $aAddOnOptions = array('element' => $aAddOnOptions);
         } elseif (is_scalar($aAddOnOptions)) {
             $aAddOnOptions = array('text' => $aAddOnOptions);
         } elseif (!is_array($aAddOnOptions)) {
-            throw new \InvalidArgumentException('Addon options expects an array or a scalar value, "' . gettype($aAddOnOptions) . '" given');
+            throw new InvalidArgumentException(sprintf(
+                'Addon options expects an array or a scalar value, "%s" given',
+                is_object($aAddOnOptions) ? get_class($aAddOnOptions) : gettype($aAddOnOptions)
+            ));
         }
 
         $sMarkup = '';
@@ -121,7 +152,10 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
         $sAddonClass = '';
         if (!empty($aAddOnOptions['text'])) {
             if (!is_scalar($aAddOnOptions['text'])) {
-                throw new \LogicException('"text" option expects a scalar value, "' . gettype($aAddOnOptions['text']) . '" given');
+                throw new InvalidArgumentException(sprintf(
+                    '"text" option expects a scalar value, "%s" given',
+                    is_object($aAddOnOptions['text']) ? get_class($aAddOnOptions['text']) : gettype($aAddOnOptions['text'])
+                ));
             } elseif (($oTranslator = $this->getTranslator())) {
                 $sMarkup .= $oTranslator->translate($aAddOnOptions['text'], $this->getTranslatorTextDomain());
             } else {
@@ -129,20 +163,27 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
             }
             $sAddonClass .= ' input-group-addon';
         } elseif (!empty($aAddOnOptions['element'])) {
-            if (
-                    is_array($aAddOnOptions['element']) || ($aAddOnOptions['element'] instanceof \Traversable && !($aAddOnOptions['element'] instanceof \Zend\Form\ElementInterface))
+            if (is_array($aAddOnOptions['element']) ||
+                ($aAddOnOptions['element'] instanceof Traversable &&
+                !($aAddOnOptions['element'] instanceof ElementInterface))
             ) {
-                $oFactory = new \Zend\Form\Factory();
+                $oFactory = new Factory();
                 $aAddOnOptions['element'] = $oFactory->create($aAddOnOptions['element']);
-            } elseif (!($aAddOnOptions['element'] instanceof \Zend\Form\ElementInterface)) {
-                throw new \LogicException(sprintf(
-                        '"element" option expects an instanceof \Zend\Form\ElementInterface, "%s" given', is_object($aAddOnOptions['element']) ? get_class($aAddOnOptions['element']) : gettype($aAddOnOptions['element'])
+            } elseif (!($aAddOnOptions['element'] instanceof ElementInterface)) {
+                throw new LogicException(sprintf(
+                    '"element" option expects an instanceof Zend\Form\ElementInterface, "%s" given',
+                    is_object($aAddOnOptions['element']) ? get_class($aAddOnOptions['element']) : gettype($aAddOnOptions['element'])
                 ));
             }
-            $aAddOnOptions['element']->setOptions(array_merge($aAddOnOptions['element']->getOptions(), array('disable-twb' => true)));
+            
+            $aAddOnOptions['element']->setOptions(array_merge(
+                $aAddOnOptions['element']->getOptions(),
+                array('disable-twb' => true)
+            ));
+            
             $sMarkup .= $this->render($aAddOnOptions['element']);
 
-            if ($aAddOnOptions['element'] instanceof \Zend\Form\Element\Button) {
+            if ($aAddOnOptions['element'] instanceof Button) {
                 $sAddonClass .= ' input-group-btn';
                 //Element contains dropdown, so add-on container must be a "div"
                 if ($aAddOnOptions['element']->getOption('dropdown')) {
@@ -158,12 +199,13 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
 
     /**
      * Sets translator to use in helper
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::setTranslator()
-     * @param \Zend\I18n\Translator\TranslatorInterface $oTranslator : [optional] translator. Default is null, which sets no translator.
+     * @see TranslatorAwareInterface::setTranslator()
+     * @param TranslatorInterface $oTranslator : [optional] translator. Default is null, which sets no translator.
      * @param string $sTextDomain : [optional] text domain Default is null, which skips setTranslatorTextDomain
-     * @return \TwbBundle\Form\View\Helper\TwbBundleFormElement
+     * @return TwbBundleFormElement
      */
-    public function setTranslator(\Zend\I18n\Translator\TranslatorInterface $oTranslator = null, $sTextDomain = null) {
+    public function setTranslator(TranslatorInterface $oTranslator = null, $sTextDomain = null)
+    {
         $this->translator = $oTranslator;
         if (null !== $sTextDomain) {
             $this->setTranslatorTextDomain($sTextDomain);
@@ -173,60 +215,65 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
 
     /**
      * Returns translator used in helper
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::getTranslator()
-     * @return null|\Zend\I18n\Translator\TranslatorInterface
+     * @see TranslatorAwareInterface::getTranslator()
+     * @return null|TranslatorInterface
      */
-    public function getTranslator() {
+    public function getTranslator()
+    {
         return $this->isTranslatorEnabled() ? $this->translator : null;
     }
 
     /**
      * Checks if the helper has a translator
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::hasTranslator()
+     * @see TranslatorAwareInterface::hasTranslator()
      * @return boolean
      */
-    public function hasTranslator() {
+    public function hasTranslator()
+    {
         return !!$this->getTranslator();
     }
 
     /**
      * Sets whether translator is enabled and should be used
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::setTranslatorEnabled()
+     * @see TranslatorAwareInterface::setTranslatorEnabled()
      * @param boolean $bEnabled
-     * @return \TwbBundle\Form\View\Helper\TwbBundleFormElement
+     * @return TwbBundleFormElement
      */
-    public function setTranslatorEnabled($bEnabled = true) {
+    public function setTranslatorEnabled($bEnabled = true)
+    {
         $this->translatorEnabled = !!$bEnabled;
         return $this;
     }
 
     /**
      * Returns whether translator is enabled and should be used
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::isTranslatorEnabled()
+     * @see TranslatorAwareInterface::isTranslatorEnabled()
      * @return boolean
      */
-    public function isTranslatorEnabled() {
+    public function isTranslatorEnabled()
+    {
         return $this->translatorEnabled;
     }
 
     /**
      * Set translation text domain
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::setTranslatorTextDomain()
+     * @see TranslatorAwareInterface::setTranslatorTextDomain()
      * @param string $sTextDomain
-     * @return \TwbBundle\Form\View\Helper\TwbBundleFormElement
+     * @return TwbBundleFormElement
      */
-    public function setTranslatorTextDomain($sTextDomain = 'default') {
+    public function setTranslatorTextDomain($sTextDomain = 'default')
+    {
         $this->translatorTextDomain = $sTextDomain;
         return $this;
     }
 
     /**
      * Return the translation text domain
-     * @see \Zend\I18n\Translator\TranslatorAwareInterface::getTranslatorTextDomain()
+     * @see TranslatorAwareInterface::getTranslatorTextDomain()
      * @return string
      */
-    public function getTranslatorTextDomain() {
+    public function getTranslatorTextDomain()
+    {
         return $this->translatorTextDomain;
     }
-
 }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormElementErrors.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormElementErrors.php
@@ -1,6 +1,10 @@
 <?php
 namespace TwbBundle\Form\View\Helper;
-class TwbBundleFormElementErrors extends \Zend\Form\View\Helper\FormElementErrors{
+
+use Zend\Form\View\Helper\FormElementErrors;
+
+class TwbBundleFormElementErrors extends FormElementErrors
+{
     protected $attributes = array(
         'class' => 'help-block'
     );

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormErrors.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormErrors.php
@@ -2,7 +2,11 @@
 
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleFormErrors extends \Zend\Form\View\Helper\AbstractHelper {
+use Zend\Form\View\Helper\AbstractHelper;
+use Zend\Form\FormInterface;
+
+class TwbBundleFormErrors extends AbstractHelper
+{
 
     protected $defaultErrorText = 'There were errors in the form submission';
     protected $messageOpenFormat = '<h4>%s</h4><ul><li>';
@@ -16,7 +20,8 @@ class TwbBundleFormErrors extends \Zend\Form\View\Helper\AbstractHelper {
      * @param string $bDismissable
      * @return string|null
      */
-    public function __invoke(\Zend\Form\FormInterface $oForm = null, $sMessage = null, $bDismissable = false) {
+    public function __invoke(FormInterface $oForm = null, $sMessage = null, $bDismissable = false)
+    {
         if (!$oForm) {
             return $this;
         }
@@ -38,7 +43,8 @@ class TwbBundleFormErrors extends \Zend\Form\View\Helper\AbstractHelper {
      * @param \Zend\Form\FormInterface $oForm
      * @return string
      */
-    public function render(\Zend\Form\FormInterface $oForm, $sMessage, $bDismissable = false) {
+    public function render(FormInterface $oForm, $sMessage, $bDismissable = false)
+    {
         $errorHtml = sprintf($this->messageOpenFormat, $sMessage);
 
         $sMessagesArray = array();
@@ -47,7 +53,9 @@ class TwbBundleFormErrors extends \Zend\Form\View\Helper\AbstractHelper {
             foreach ($sMessages as $sMessage) {
                 if ($oForm->get($fieldName)->getAttribute('id')) {
                     $sMessagesArray[] = sprintf(
-                            '<a href="#%s">%s</a>', $oForm->get($fieldName)->getAttribute('id'), $oForm->get($fieldName)->getLabel() . ': ' . $sMessage
+                        '<a href="#%s">%s</a>',
+                        $oForm->get($fieldName)->getAttribute('id'),
+                        $oForm->get($fieldName)->getLabel() . ': ' . $sMessage
                     );
                 } else {
                     $sMessagesArray[] = $oForm->get($fieldName)->getLabel() . ': ' . $sMessage;
@@ -55,7 +63,12 @@ class TwbBundleFormErrors extends \Zend\Form\View\Helper\AbstractHelper {
             }
         }
 
-        return $this->dangerAlert($errorHtml . implode($this->messageSeparatorString, $sMessagesArray) . $this->messageCloseString, $bDismissable);
+        return $this->dangerAlert(
+            $errorHtml .
+            implode($this->messageSeparatorString, $sMessagesArray) .
+            $this->messageCloseString,
+            $bDismissable
+        );
     }
 
     /**
@@ -64,8 +77,8 @@ class TwbBundleFormErrors extends \Zend\Form\View\Helper\AbstractHelper {
      * @param boolean $bDismissable
      * @return string
      */
-    public function dangerAlert($content, $bDismissable = false) {
+    public function dangerAlert($content, $bDismissable = false)
+    {
         return $this->getView()->alert($content, array('class' => 'alert-danger'), $bDismissable);
     }
-
 }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormMultiCheckbox.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormMultiCheckbox.php
@@ -2,14 +2,19 @@
 
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleFormMultiCheckbox extends \Zend\Form\View\Helper\FormMultiCheckbox {
+use Zend\Form\View\Helper\FormMultiCheckbox;
+use Zend\Form\ElementInterface;
+
+class TwbBundleFormMultiCheckbox extends FormMultiCheckbox
+{
 
     /**
      * @see \Zend\Form\View\Helper\FormMultiCheckbox::render()
      * @param \Zend\Form\ElementInterface $oElement
      * @return string
      */
-    public function render(\Zend\Form\ElementInterface $oElement) {
+    public function render(ElementInterface $oElement)
+    {
 
         $aElementOptions = $oElement->getOptions();
 
@@ -26,5 +31,4 @@ class TwbBundleFormMultiCheckbox extends \Zend\Form\View\Helper\FormMultiCheckbo
 
         return $bNoInline ? '<div class="checkbox">' . parent::render($oElement) . '</div>' : parent::render($oElement);
     }
-
 }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRadio.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRadio.php
@@ -2,7 +2,12 @@
 
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleFormRadio extends \Zend\Form\View\Helper\FormRadio {
+use Zend\Form\View\Helper\FormRadio;
+use Zend\Form\ElementInterface;
+use Zend\Form\Element\MultiCheckbox;
+
+class TwbBundleFormRadio extends FormRadio
+{
 
     /**
      * Separator for checkbox elements
@@ -20,7 +25,8 @@ class TwbBundleFormRadio extends \Zend\Form\View\Helper\FormRadio {
      * @param \Zend\Form\ElementInterface $oElement
      * @return string
      */
-    public function render(\Zend\Form\ElementInterface $oElement) {
+    public function render(ElementInterface $oElement)
+    {
         if ($oElement->getOption('disable-twb')) {
             $sSeparator = $this->separator;
             $this->separator = '';
@@ -39,7 +45,12 @@ class TwbBundleFormRadio extends \Zend\Form\View\Helper\FormRadio {
      * @param array $aAttributes
      * @return string
      */
-    protected function renderOptions(\Zend\Form\Element\MultiCheckbox $oElement, array $aOptions, array $aSelectedOptions, array $aAttributes) {
+    protected function renderOptions(
+        MultiCheckbox $oElement,
+        array $aOptions,
+        array $aSelectedOptions,
+        array $aAttributes
+    ) {
         $iIterator = 0;
         $aGlobalLabelAttributes = $oElement->getLabelAttributes()? : $this->labelAttributes;
         $sMarkup = '';
@@ -112,5 +123,4 @@ class TwbBundleFormRadio extends \Zend\Form\View\Helper\FormRadio {
         }
         return $sMarkup;
     }
-
 }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -2,8 +2,15 @@
 
 namespace TwbBundle\Form\View\Helper;
 
-class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
+use DomainException;
+use Zend\Form\View\Helper\FormRow;
+use Zend\Form\ElementInterface;
+use Zend\Form\LabelAwareInterface;
+use Zend\Form\Element\Button;
+use Zend\Form\Element\Submit;
 
+class TwbBundleFormRow extends FormRow
+{
     /**
      * @var string
      */
@@ -36,11 +43,12 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
     protected $requiredFormat = null;
 
     /**
-     * @see \Zend\Form\View\Helper\FormRow::render()
-     * @param \Zend\Form\ElementInterface $oElement
+     * @see FormRow::render()
+     * @param ElementInterface $oElement
      * @return string
      */
-    public function render(\Zend\Form\ElementInterface $oElement) {
+    public function render(ElementInterface $oElement)
+    {
         $sElementType = $oElement->getAttribute('type');
 
         //Nothing to do for hidden elements which have no messages
@@ -85,8 +93,8 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
         }
 
         //Column size
-        if (
-                ($sColumSize = $oElement->getOption('column-size')) && $sLayout !== \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_HORIZONTAL
+        if (($sColumSize = $oElement->getOption('column-size')) &&
+            $sLayout !== TwbBundleForm::LAYOUT_HORIZONTAL
         ) {
             $sRowClass .= ' col-' . $sColumSize;
         }
@@ -95,10 +103,11 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
         $sElementContent = $this->renderElement($oElement);
 
         //Render form row
-        if ($sElementType === 'checkbox' && $sLayout !== \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_HORIZONTAL) {
+        if ($sElementType === 'checkbox' && $sLayout !== TwbBundleForm::LAYOUT_HORIZONTAL) {
             return $sElementContent . PHP_EOL;
         }
-        if (($sElementType === 'submit' || $sElementType === 'button' || $sElementType === 'reset') && $sLayout === \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_INLINE
+        if (($sElementType === 'submit' || $sElementType === 'button' || $sElementType === 'reset')
+            && $sLayout === TwbBundleForm::LAYOUT_INLINE
         ) {
             return $sElementContent . PHP_EOL;
         }
@@ -108,10 +117,11 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
 
     /**
      * Render element's label
-     * @param \Zend\Form\ElementInterface $oElement
+     * @param ElementInterface $oElement
      * @return string
      */
-    protected function renderLabel(\Zend\Form\ElementInterface $oElement) {
+    protected function renderLabel(ElementInterface $oElement)
+    {
         if (($sLabel = $oElement->getLabel()) && ($oTranslator = $this->getTranslator())) {
             $sLabel = $oTranslator->translate($sLabel, $this->getTranslatorTextDomain());
         }
@@ -120,22 +130,27 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
 
     /**
      * Render element
-     * @param \Zend\Form\ElementInterface $oElement
-     * @throws \DomainException
+     * @param ElementInterface $oElement
+     * @throws DomainException
      * @return string
      */
-    protected function renderElement(\Zend\Form\ElementInterface $oElement) {
+    protected function renderElement(ElementInterface $oElement)
+    {
         //Retrieve expected layout
         $sLayout = $oElement->getOption('twb-layout');
 
         //Render label
         $sLabelOpen = $sLabelClose = $sLabelContent = $sElementType = '';
         if ($sLabelContent = $this->renderLabel($oElement)) {
-            //Multicheckbox elements have to be handled differently as the HTML standard does not allow nested labels. The semantic way is to group them inside a fieldset
+            /*
+             * Multicheckbox elements have to be handled differently
+             * as the HTML standard does not allow nested labels.
+             * The semantic way is to group them inside a fieldset
+             */
             $sElementType = $oElement->getAttribute('type');
 
             //Button element is a special case, because label is always rendered inside it
-            if (($oElement instanceof \Zend\Form\Element\Button) or ($oElement instanceof \Zend\Form\Element\Submit)) {
+            if (($oElement instanceof Button) or ($oElement instanceof Submit)) {
                 $sLabelContent = '';
             } else {
                 $aLabelAttributes = $oElement->getLabelAttributes() ? : $this->labelAttributes;
@@ -152,7 +167,7 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
                 $oLabelHelper = $this->getLabelHelper();
                 switch ($sLayout) {
                     //Hide label for "inline" layout
-                    case \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_INLINE:
+                    case TwbBundleForm::LAYOUT_INLINE:
                         if ($sElementType !== 'checkbox') {
                             if (empty($aLabelAttributes['class'])) {
                                 $aLabelAttributes['class'] = 'sr-only';
@@ -162,7 +177,7 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
                         }
                         break;
 
-                    case \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_HORIZONTAL:
+                    case TwbBundleForm::LAYOUT_HORIZONTAL:
                         if ($sElementType !== 'checkbox') {
                             if (empty($aLabelAttributes['class'])) {
                                 $aLabelAttributes['class'] = 'control-label';
@@ -184,20 +199,23 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
                 // Allow label html escape desable
                 //$sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
 
-                if (!$oElement instanceof \Zend\Form\LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
+                if (!$oElement instanceof LabelAwareInterface || !$oElement->getLabelOption('disable_html_escape')) {
                     $sLabelContent = $this->getEscapeHtmlHelper()->__invoke($sLabelContent);
                 }
             }
         }
 
         //Add required string if element is required
-        if ($this->requiredFormat && $oElement->getAttribute('required') && strpos($this->requiredFormat, $sLabelContent) === false) {
+        if ($this->requiredFormat &&
+            $oElement->getAttribute('required') &&
+            strpos($this->requiredFormat, $sLabelContent) === false
+        ) {
             $sLabelContent .= $this->requiredFormat;
         }
 
         switch ($sLayout) {
             case null:
-            case \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_INLINE:
+            case TwbBundleForm::LAYOUT_INLINE:
 
                 $sElementContent = $this->getElementHelper()->render($oElement);
 
@@ -222,7 +240,7 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
 
                 return $sElementContent;
 
-            case \TwbBundle\Form\View\Helper\TwbBundleForm::LAYOUT_HORIZONTAL:
+            case TwbBundleForm::LAYOUT_HORIZONTAL:
                 $sElementContent = $this->getElementHelper()->render($oElement) . $this->renderHelpBlock($oElement);
 
                 //Render errors
@@ -240,34 +258,39 @@ class TwbBundleFormRow extends \Zend\Form\View\Helper\FormRow {
                 // Checkbox elements are a special case, element is rendered into label
                 if ($sElementType === 'checkbox') {
                     return sprintf(
-                            self::$horizontalLayoutFormat, $sClass, sprintf(self::$checkboxFormat, $sElementContent)
+                        self::$horizontalLayoutFormat,
+                        $sClass,
+                        sprintf(self::$checkboxFormat, $sElementContent)
                     );
                 }
 
                 if ($this->getLabelPosition() === self::LABEL_PREPEND) {
                     return $sLabelOpen . $sLabelContent . $sLabelClose . sprintf(
-                                    self::$horizontalLayoutFormat, $sClass, $sElementContent
+                        self::$horizontalLayoutFormat,
+                        $sClass,
+                        $sElementContent
                     );
                 } else {
                     return sprintf(
-                                    self::$horizontalLayoutFormat, $sClass, $sElementContent
-                            ) . $sLabelOpen . $sLabelContent . $sLabelClose;
+                        self::$horizontalLayoutFormat,
+                        $sClass,
+                        $sElementContent
+                    ) . $sLabelOpen . $sLabelContent . $sLabelClose;
                 }
-
-            default:
-                throw new \DomainException('Layout "' . $sLayout . '" is not valid');
         }
+        throw new DomainException('Layout "' . $sLayout . '" is not valid');
     }
 
     /**
      * Render element's help block
-     * @param \Zend\Form\ElementInterface $oElement
+     * @param ElementInterface $oElement
      * @return string
      */
-    protected function renderHelpBlock(\Zend\Form\ElementInterface $oElement) {
+    protected function renderHelpBlock(ElementInterface $oElement)
+    {
         return ($sHelpBlock = $oElement->getOption('help-block')) ? sprintf(
-                        self::$helpBlockFormat, $this->getEscapeHtmlHelper()->__invoke(($oTranslator = $this->getTranslator()) ? $oTranslator->translate($sHelpBlock, $this->getTranslatorTextDomain()) : $sHelpBlock)
-                ) : '';
+            self::$helpBlockFormat,
+            $this->getEscapeHtmlHelper()->__invoke(($oTranslator = $this->getTranslator()) ? $oTranslator->translate($sHelpBlock, $this->getTranslatorTextDomain()) : $sHelpBlock)
+        ) : '';
     }
-
 }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormStatic.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormStatic.php
@@ -2,12 +2,14 @@
 namespace TwbBundle\Form\View\Helper;
 
 use Zend\Form\ElementInterface;
+use Zend\View\Helper\AbstractHelper;
 
-class TwbBundleFormStatic extends \Zend\Form\View\Helper\AbstractHelper{
-	/**
-	 * @var string
-	 */
-	private static $staticFormat = '<p class="form-control-static">%s</p>';
+class TwbBundleFormStatic extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    private static $staticFormat = '<p class="form-control-static">%s</p>';
 
     /**
      * Invoke helper as functor
@@ -26,12 +28,13 @@ class TwbBundleFormStatic extends \Zend\Form\View\Helper\AbstractHelper{
         return $this->render($element);
     }
 
-	/**
-	 * @see \Zend\Form\View\Helper\AbstractHelper::render()
-	 * @param ElementInterface $oElement
-	 * @return string
-	 */
-	public function render(ElementInterface $oElement){
-		return sprintf(self::$staticFormat,$oElement->getValue());
-	}
+    /**
+     * @see \Zend\Form\View\Helper\AbstractHelper::render()
+     * @param ElementInterface $oElement
+     * @return string
+     */
+    public function render(ElementInterface $oElement)
+    {
+        return sprintf(self::$staticFormat, $oElement->getValue());
+    }
 }

--- a/src/TwbBundle/Options/Factory/ModuleOptionsFactory.php
+++ b/src/TwbBundle/Options/Factory/ModuleOptionsFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TwbBundle\Options\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use TwbBundle\Options\ModuleOptions;
+
+class ModuleOptionsFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('Config');
+        $options = $config['twbbundle'];
+        return new ModuleOptions($options);
+    }
+}

--- a/src/TwbBundle/Options/ModuleOptions.php
+++ b/src/TwbBundle/Options/ModuleOptions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TwbBundle\Options;
+
+use Zend\Stdlib\AbstractOptions;
+
+/**
+ * Hold options for TwbBundle module
+ */
+class ModuleOptions extends AbstractOptions
+{
+    protected $ignoredViewHelpers;
+    
+    public function getIgnoredViewHelpers()
+    {
+        return $this->ignoredViewHelpers;
+    }
+
+    public function setIgnoredViewHelpers($ignoredViewHelpers)
+    {
+        $this->ignoredViewHelpers = $ignoredViewHelpers;
+    }
+}

--- a/src/TwbBundle/View/Helper/TwbBundleAlert.php
+++ b/src/TwbBundle/View/Helper/TwbBundleAlert.php
@@ -1,57 +1,85 @@
 <?php
+
 namespace TwbBundle\View\Helper;
-class TwbBundleAlert extends \Zend\Form\View\Helper\AbstractHelper{
-	/**
-	 * @var string
-	 */
-	private static $alertFormat = '<div %s>%s</div>';
 
-	/**
-	 * @var string
-	 */
-	private static $dismissButtonFormat = '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>';
+use InvalidArgumentException;
+use Zend\Form\View\Helper\AbstractHelper;
 
-	/**
-	 * Invoke helper as functor, proxies to {@link render()}.
-	 * @param string $sAlertMessage
-	 * @param string|array $aAlertAttributes : [optionnal] if string, alert class
-	 * @param boolean $bDismissable
-	 * @return string|\TwbBundle\View\Helper\TwbBundleAlert
-	 */
-	public function __invoke($sAlertMessage = null, $aAlertAttributes = null, $bDismissable = false){
-		if($sAlertMessage === null) return $this;
-		if($sAlertMessage === '' || $sAlertMessage === false) return '';
-		return $this->render($sAlertMessage,$aAlertAttributes,$bDismissable);
-	}
+class TwbBundleAlert extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    private static $alertFormat = '<div %s>%s</div>';
 
-	/**
-	 * Retrieve alert markup
-	 * @param string $sAlertMessage
-	 * @param  string|array $aAlertAttributes : [optionnal] if string, alert class
-	 * @param boolean $bDismissable
-	 * @throws \InvalidArgumentException
-	 * @return string
-	 */
-	public function render($sAlertMessage, $aAlertAttributes = null, $bDismissable = false){
-		if(!is_scalar($sAlertMessage))throw new \InvalidArgumentException('Alert message expects a scalar value, "'.gettype($sAlertMessage).'" given');
-		if(empty($aAlertAttributes))$aAlertAttributes = array('class' => 'alert');
-		elseif(is_string($aAlertAttributes))$aAlertAttributes = array('class' => $aAlertAttributes);
-		elseif(!is_array($aAlertAttributes))throw new \InvalidArgumentException('Alert attributes expects a string or an array, "'.gettype($aAlertAttributes).'" given');
-		elseif(empty($aAlertAttributes['class']))throw new \InvalidArgumentException('Alert "class" attribute is empty');
-		elseif(!is_string($aAlertAttributes['class']))throw new \InvalidArgumentException('Alert "class" attribute expects string, "'.gettype($aAlertAttributes).'" given');
+    /**
+     * @var string
+     */
+    private static $dismissButtonFormat = '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>';
 
-		if(!preg_match('/(\s|^)alert(\s|$)/',$aAlertAttributes['class']))$aAlertAttributes['class'] .= ' alert';
-		if(null !== ($oTranslator = $this->getTranslator()))$sAlertMessage = $oTranslator->translate($sAlertMessage, $this->getTranslatorTextDomain());
+    /**
+     * Invoke helper as functor, proxies to {@link render()}.
+     * @param string $sAlertMessage
+     * @param string|array $aAlertAttributes : [optionnal] if string, alert class
+     * @param boolean $bDismissable
+     * @return string|TwbBundleAlert
+     */
+    public function __invoke($sAlertMessage = null, $aAlertAttributes = null, $bDismissable = false)
+    {
+        if ($sAlertMessage === null) {
+            return $this;
+        }
+        if ($sAlertMessage === '' || $sAlertMessage === false) {
+            return '';
+        }
+        return $this->render($sAlertMessage, $aAlertAttributes, $bDismissable);
+    }
 
-		if($bDismissable){
-			$sAlertMessage = self::$dismissButtonFormat . $sAlertMessage;
-			if(!preg_match('/(\s|^)alert-dismissable(\s|$)/',$aAlertAttributes['class']))$aAlertAttributes['class'] .= ' alert-dismissable';
-		}
+    /**
+     * Retrieve alert markup
+     * @param string $sAlertMessage
+     * @param  string|array $aAlertAttributes : [optionnal] if string, alert class
+     * @param boolean $bDismissable
+     * @throws InvalidArgumentException
+     * @return string
+     */
+    public function render($sAlertMessage, $aAlertAttributes = null, $bDismissable = false)
+    {
+        if (!is_scalar($sAlertMessage)) {
+            throw new InvalidArgumentException('Alert message expects a scalar value, "' . gettype($sAlertMessage) . '" given');
+        }
+        
+        if (empty($aAlertAttributes)) {
+            $aAlertAttributes = array('class' => 'alert');
+        } elseif (is_string($aAlertAttributes)) {
+            $aAlertAttributes = array('class' => $aAlertAttributes);
+        } elseif (!is_array($aAlertAttributes)) {
+            throw new InvalidArgumentException('Alert attributes expects a string or an array, "' . gettype($aAlertAttributes) . '" given');
+        } elseif (empty($aAlertAttributes['class'])) {
+            throw new InvalidArgumentException('Alert "class" attribute is empty');
+        } elseif (!is_string($aAlertAttributes['class'])) {
+            throw new InvalidArgumentException('Alert "class" attribute expects string, "' . gettype($aAlertAttributes) . '" given');
+        }
 
-		return sprintf(
-			self::$alertFormat,
-			$this->createAttributesString($aAlertAttributes),
-			$sAlertMessage
-		);
-	}
+        if (!preg_match('/(\s|^)alert(\s|$)/', $aAlertAttributes['class'])) {
+            $aAlertAttributes['class'] .= ' alert';
+        }
+        
+        if (null !== ($oTranslator = $this->getTranslator())) {
+            $sAlertMessage = $oTranslator->translate($sAlertMessage, $this->getTranslatorTextDomain());
+        }
+
+        if ($bDismissable) {
+            $sAlertMessage = self::$dismissButtonFormat . $sAlertMessage;
+            if (!preg_match('/(\s|^)alert-dismissable(\s|$)/', $aAlertAttributes['class'])) {
+                $aAlertAttributes['class'] .= ' alert-dismissable';
+            }
+        }
+
+        return sprintf(
+            self::$alertFormat,
+            $this->createAttributesString($aAlertAttributes),
+            $sAlertMessage
+        );
+    }
 }

--- a/src/TwbBundle/View/Helper/TwbBundleBadge.php
+++ b/src/TwbBundle/View/Helper/TwbBundleBadge.php
@@ -1,42 +1,65 @@
 <?php
-namespace TwbBundle\View\Helper;
-class TwbBundleBadge extends \Zend\Form\View\Helper\AbstractHelper{
-	/**
-	 * @var string
-	 */
-	private static $badgeFormat = '<span %s>%s</span>';
 
-	/**
-	 * Invoke helper as functor, proxies to {@link render()}.
-	 * @param string $sBadgeMessage
-	 * @param array $aBadgeAttributes : [optionnal]
-	 * @return string|\TwbBundle\View\Helper\TwbBundleBadge
-	 */
-    public function __invoke($sBadgeMessage = null, array $aBadgeAttributes = null){
-        if(!$sBadgeMessage)return $this;
-        return $this->render($sBadgeMessage,$aBadgeAttributes);
+namespace TwbBundle\View\Helper;
+
+use Zend\Form\View\Helper\AbstractHelper;
+use InvalidArgumentException;
+
+class TwbBundleBadge extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    private static $badgeFormat = '<span %s>%s</span>';
+
+    /**
+     * Invoke helper as functor, proxies to {@link render()}.
+     * @param string $sBadgeMessage
+     * @param array $aBadgeAttributes : [optionnal]
+     * @return string|TwbBundleBadge
+     */
+    public function __invoke($sBadgeMessage = null, array $aBadgeAttributes = null)
+    {
+        if (!$sBadgeMessage) {
+            return $this;
+        }
+        return $this->render($sBadgeMessage, $aBadgeAttributes);
     }
 
     /**
      * Retrieve badge markup
      * @param string $sBadgeMessage
      * @param  array $aBadgeAttributes : [optionnal]
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return string
      */
-	public function render($sBadgeMessage,array $aBadgeAttributes = null){
-		if(!is_scalar($sBadgeMessage))throw new \InvalidArgumentException('Badge message expects a scalar value, "'.gettype($sBadgeMessage).'" given');
+    public function render($sBadgeMessage, array $aBadgeAttributes = null)
+    {
+        if (!is_scalar($sBadgeMessage)) {
+            throw new InvalidArgumentException(sprintf(
+                'Badge message expects a scalar value, "%s" given',
+                is_object($sBadgeMessage) ? get_class($sBadgeMessage) : gettype($sBadgeMessage)
+            ));
+        }
 
-		if(empty($aBadgeAttributes))$aBadgeAttributes = array('class' => 'badge');
-		else{
-			if(empty($aBadgeAttributes['class']))$aBadgeAttributes['class'] = 'badge';
-			elseif(!preg_match('/(\s|^)badge(\s|$)/',$aBadgeAttributes['class']))$aBadgeAttributes['class'] .= ' badge';
-		}
-		if(null !== ($oTranslator = $this->getTranslator()))$sBadgeMessage = $oTranslator->translate($sBadgeMessage, $this->getTranslatorTextDomain());
-		return sprintf(
-			self::$badgeFormat,
-			$this->createAttributesString($aBadgeAttributes),
-			$sBadgeMessage
-		);
-	}
+        if (empty($aBadgeAttributes)) {
+            $aBadgeAttributes = array('class' => 'badge');
+        } else {
+            if (empty($aBadgeAttributes['class'])) {
+                $aBadgeAttributes['class'] = 'badge';
+            } elseif (!preg_match('/(\s|^)badge(\s|$)/', $aBadgeAttributes['class'])) {
+                $aBadgeAttributes['class'] .= ' badge';
+            }
+        }
+        
+        if (null !== ($oTranslator = $this->getTranslator())) {
+            $sBadgeMessage = $oTranslator->translate($sBadgeMessage, $this->getTranslatorTextDomain());
+        }
+        
+        return sprintf(
+            self::$badgeFormat,
+            $this->createAttributesString($aBadgeAttributes),
+            $sBadgeMessage
+        );
+    }
 }

--- a/src/TwbBundle/View/Helper/TwbBundleButtonGroup.php
+++ b/src/TwbBundle/View/Helper/TwbBundleButtonGroup.php
@@ -2,8 +2,14 @@
 
 namespace TwbBundle\View\Helper;
 
-class TwbBundleButtonGroup extends \Zend\Form\View\Helper\AbstractHelper {
+use Traversable;
+use LogicException;
+use Zend\Form\View\Helper\AbstractHelper;
+use Zend\Form\ElementInterface;
+use Zend\Form\Factory;
 
+class TwbBundleButtonGroup extends AbstractHelper
+{
     /**
      * @var string
      */
@@ -15,16 +21,17 @@ class TwbBundleButtonGroup extends \Zend\Form\View\Helper\AbstractHelper {
     protected static $buttonGroupJustifiedFormat = '<div class="btn-group">%s</div>';
 
     /**
-     * @var \TwbBundle\Form\View\Helper\TwbBundleFormElement
+     * @var TwbBundleFormElement
      */
     protected $formElementHelper;
 
     /**
      * @param array $aButtons
      * @param array $aButtonGroupOptions
-     * @return \TwbBundle\View\Helper\TwbBundleButtonGroup|string
+     * @return TwbBundleButtonGroup|string
      */
-    public function __invoke(array $aButtons = null, array $aButtonGroupOptions = null) {
+    public function __invoke(array $aButtons = null, array $aButtonGroupOptions = null)
+    {
         return $aButtons ? $this->render($aButtons, $aButtonGroupOptions) : $this;
     }
 
@@ -32,16 +39,19 @@ class TwbBundleButtonGroup extends \Zend\Form\View\Helper\AbstractHelper {
      * Render button groups markup
      * @param array $aButtons
      * @param array $aButtonGroupOptions
-     * @throws \LogicException
+     * @throws LogicException
      * @return string
      */
-    public function render(array $aButtons, array $aButtonGroupOptions = null) {
-        // ### Button group container attributes ###
+    public function render(array $aButtons, array $aButtonGroupOptions = null)
+    {
+        /*
+         * Button group container attributes
+         */
         if (empty($aButtonGroupOptions['attributes'])) {
             $aButtonGroupOptions['attributes'] = array('class' => 'btn-group');
         } else {
             if (!is_array($aButtonGroupOptions['attributes'])) {
-                throw new \LogicException('"attributes" option expects an array, "' . gettype($aButtonGroupOptions['attributes']) . '" given');
+                throw new LogicException('"attributes" option expects an array, "' . gettype($aButtonGroupOptions['attributes']) . '" given');
             }
             if (empty($aButtonGroupOptions['attributes']['class'])) {
                 $aButtonGroupOptions['attributes']['class'] = 'btn-group';
@@ -50,14 +60,18 @@ class TwbBundleButtonGroup extends \Zend\Form\View\Helper\AbstractHelper {
             }
         }
 
-        // ### Render button group ###
-
+        /*
+         * Render button group
+         */
         return sprintf(
-                self::$buttonGroupContainerFormat,
-                //Container attributes
-                $this->createAttributesString($aButtonGroupOptions['attributes']),
-                //Buttons
-                $this->renderButtons($aButtons, strpos($aButtonGroupOptions['attributes']['class'], 'btn-group-justified') !== false)
+            self::$buttonGroupContainerFormat,
+            //Container attributes
+            $this->createAttributesString($aButtonGroupOptions['attributes']),
+            //Buttons
+            $this->renderButtons(
+                $aButtons,
+                strpos($aButtonGroupOptions['attributes']['class'], 'btn-group-justified') !== false
+            )
         );
     }
 
@@ -66,17 +80,19 @@ class TwbBundleButtonGroup extends \Zend\Form\View\Helper\AbstractHelper {
      * @param array $aButtons
      * @return string
      */
-    protected function renderButtons(array $aButtons, $bJustified = false) {
+    protected function renderButtons(array $aButtons, $bJustified = false)
+    {
         $sMarkup = '';
         foreach ($aButtons as $oButton) {
-            if (
-                    is_array($oButton) || ($oButton instanceof \Traversable && !($oButton instanceof \Zend\Form\ElementInterface))
+            if (is_array($oButton) ||
+                ($oButton instanceof Traversable &&
+                !($oButton instanceof ElementInterface))
             ) {
-                $oFactory = new \Zend\Form\Factory();
+                $oFactory = new Factory();
                 $oButton = $oFactory->create($oButton);
-            } elseif (!($oButton instanceof \Zend\Form\ElementInterface)) {
-                throw new \LogicException(sprintf(
-                        'Button expects an instanceof \Zend\Form\ElementInterface or an array / \Traversable, "%s" given', is_object($oButton) ? get_class($oButton) : gettype($oButton)
+            } elseif (!($oButton instanceof ElementInterface)) {
+                throw new LogicException(sprintf(
+                    'Button expects an instanceof Zend\Form\ElementInterface or an array / Traversable, "%s" given', is_object($oButton) ? get_class($oButton) : gettype($oButton)
                 ));
             }
 
@@ -88,17 +104,17 @@ class TwbBundleButtonGroup extends \Zend\Form\View\Helper\AbstractHelper {
     }
 
     /**
-     * @return \TwbBundle\Form\View\Helper\TwbBundleFormElement
+     * @return TwbBundleFormElement
      */
-    public function getFormElementHelper() {
-        if ($this->formElementHelper instanceof \TwbBundle\Form\View\Helper\TwbBundleFormElement) {
+    public function getFormElementHelper()
+    {
+        if ($this->formElementHelper instanceof TwbBundleFormElement) {
             return $this->formElementHelper;
         }
         if (method_exists($this->view, 'plugin')) {
             return $this->formElementHelper = $this->view->plugin('form_element');
         }
 
-        return $this->formElementHelper = new \TwbBundle\Form\View\Helper\TwbBundleFormElement();
+        return $this->formElementHelper = new TwbBundleFormElement();
     }
-
 }

--- a/src/TwbBundle/View/Helper/TwbBundleDropdown.php
+++ b/src/TwbBundle/View/Helper/TwbBundleDropdown.php
@@ -1,256 +1,373 @@
 <?php
+
 namespace TwbBundle\View\Helper;
-class TwbBundleDropDown extends \Zend\Form\View\Helper\AbstractHelper{
-	const TYPE_ITEM_HEADER = 'header';
-	const TYPE_ITEM_DIVIDER = '---';
-	const TYPE_ITEM_LINK = 'link';
 
-	/**
-	 * @var string
-	 */
-	private static $dropdownContainerFormat = '<div %s>%s</div>';
+use Zend\Form\View\Helper\AbstractHelper;
+use LogicException;
+use InvalidArgumentException;
 
-	/**
-	 * @var string
-	 */
-	private static $dropdownToggleFormat = '<a %s>%s <b class="caret"></b></a>';
+class TwbBundleDropDown extends AbstractHelper
+{
+    const TYPE_ITEM_HEADER = 'header';
+    const TYPE_ITEM_DIVIDER = '---';
+    const TYPE_ITEM_LINK = 'link';
 
-	/**
-	 * @var string
-	 */
-	private static $dropdownListFormat = '<ul %s>%s</ul>';
+    /**
+     * @var string
+     */
+    private static $dropdownContainerFormat = '<div %s>%s</div>';
 
-	/**
-	 * @var string
-	 */
-	private static $dropdownItemContainerFormat = '<li %s>%s</li>';
+    /**
+     * @var string
+     */
+    private static $dropdownToggleFormat = '<a %s>%s <b class="caret"></b></a>';
 
-	/**
-	 * @var string
-	 */
-	private static $dropdownItemFormats = array(
-		self::TYPE_ITEM_LINK => '<a %s>%s</a>'
-	);
+    /**
+     * @var string
+     */
+    private static $dropdownListFormat = '<ul %s>%s</ul>';
 
-	/**
-	 * @param array $aDropdownOptions
-	 * @return \TwbBundle\View\Helper\TwbBundleDropDown|string
-	 */
-    public function __invoke(array $aDropdownOptions = null){
-		return $aDropdownOptions?$this->render($aDropdownOptions):$this;
+    /**
+     * @var string
+     */
+    private static $dropdownItemContainerFormat = '<li %s>%s</li>';
+
+    /**
+     * @var string
+     */
+    private static $dropdownItemFormats = array(
+        self::TYPE_ITEM_LINK => '<a %s>%s</a>'
+    );
+
+    /**
+     * @param array $aDropdownOptions
+     * @return TwbBundleDropDown|string
+     */
+    public function __invoke(array $aDropdownOptions = null)
+    {
+        return $aDropdownOptions ? $this->render($aDropdownOptions) : $this;
     }
 
-	/**
-	 * Render dropdown markup
-	 * @param array $aDropdownOptions
-	 * @throws \LogicException
-	 * @return string
-	 */
-	public function render(array $aDropdownOptions){
-		// ### Dropdown container attributes ###
-		if(empty($aDropdownOptions['attributes']))$aDropdownOptions['attributes'] = array('class' => 'dropdown');
-		else{
-			if(!is_array($aDropdownOptions['attributes']))throw new \LogicException('"attributes" option expects an array, "'.gettype($aDropdownOptions['attributes']).'" given');
-			if(empty($aDropdownOptions['attributes']['class']))$aDropdownOptions['attributes']['class'] = 'dropdown';
-			elseif(!preg_match('/(\s|^)dropdown(\s|$)/',$aDropdownOptions['attributes']['class']))$aDropdownOptions['attributes']['class'] .= ' dropdown';
-		}
+    /**
+     * Render dropdown markup
+     * @param array $aDropdownOptions
+     * @throws LogicException
+     * @return string
+     */
+    public function render(array $aDropdownOptions)
+    {
+        /*
+         * Dropdown container attributes
+         */
+        if (empty($aDropdownOptions['attributes'])) {
 
-		// ### Render dropdown ###
+            $aDropdownOptions['attributes'] = array('class' => 'dropdown');
+        } else {
+            if (!is_array($aDropdownOptions['attributes'])) {
+                throw new LogicException('"attributes" option expects an array, "' . gettype($aDropdownOptions['attributes']) . '" given');
+            }
 
-		return sprintf(
-			self::$dropdownContainerFormat,
-			//Container attributes
-			$this->createAttributesString($aDropdownOptions['attributes']),
-			//Toggle
-			$this->renderToggle($aDropdownOptions).
-			//List items
-			$this->renderListItems($aDropdownOptions)
-		);
-	}
+            if (empty($aDropdownOptions['attributes']['class'])) {
 
-	/**
-	 * Render dropdown toggle markup
-	 * @param array $aDropdownOptions
-	 * @throws \LogicException
-	 * @return string
-	 */
-	public function renderToggle(array $aDropdownOptions){
-		// ### Dropdown toggle ###
-		if(empty($aDropdownOptions['label']))$aDropdownOptions['label'] = '';
-		elseif(!is_scalar($aDropdownOptions['label']))throw new \InvalidArgumentException('"label" option expects a scalar value, "'.gettype($aDropdownOptions['label']).'" given');
-		elseif(($oTranslator = $this->getTranslator()))$aDropdownOptions['label'] = $oTranslator->translate($aDropdownOptions['label'],$this->getTranslatorTextDomain());
+                $aDropdownOptions['attributes']['class'] = 'dropdown';
+            } elseif (!preg_match('/(\s|^)dropdown(\s|$)/', $aDropdownOptions['attributes']['class'])) {
 
-		//Dropdown toggle attributes
+                $aDropdownOptions['attributes']['class'] .= ' dropdown';
+            }
+        }
 
-		//Class
-		if(empty($aDropdownOptions['toggle_attributes']))$aDropdownOptions['toggle_attributes'] = array('class' => 'sr-only dropdown-toggle');
-		else{
-			if(!is_array($aDropdownOptions['toggle_attributes']))throw new \InvalidArgumentException('"toggle_attributes" option expects an array, "'.gettype($aDropdownOptions['toggle_attributes']).'" given');
-			if(empty($aDropdownOptions['toggle_attributes']['class']))$aDropdownOptions['toggle_attributes']['class'] = 'sr-only dropdown-toggle';
-			else{
-				if(!preg_match('/(\s|^)sr-only(\s|$)/',$aDropdownOptions['toggle_attributes']['class']))$aDropdownOptions['toggle_attributes']['class'] .= ' sr-only';
-				if(!preg_match('/(\s|^)dropdown-toggle(\s|$)/',$aDropdownOptions['toggle_attributes']['class']))$aDropdownOptions['toggle_attributes']['class'] .= ' dropdown-toggle';
-			}
-		}
+        /*
+         * Render dropdown
+         */
+        return sprintf(
+            self::$dropdownContainerFormat,
+            $this->createAttributesString($aDropdownOptions['attributes']), //Container attributes
+            $this->renderToggle($aDropdownOptions) . //Toggle
+            $this->renderListItems($aDropdownOptions) //List items
+        );
+    }
 
-		//data-toggle
-		if(empty($aDropdownOptions['toggle_attributes']['data-toggle']))$aDropdownOptions['toggle_attributes']['data-toggle'] = 'dropdown';
+    /**
+     * Render dropdown toggle markup
+     * @param array $aDropdownOptions
+     * @throws LogicException
+     * @return string
+     */
+    public function renderToggle(array $aDropdownOptions)
+    {
+        /*
+         * Dropdown toggle
+         */
+        if (empty($aDropdownOptions['label'])) {
+            $aDropdownOptions['label'] = '';
+        } elseif (!is_scalar($aDropdownOptions['label'])) {
+            throw new InvalidArgumentException('"label" option expects a scalar value, "' . gettype($aDropdownOptions['label']) . '" given');
+        } elseif (($oTranslator = $this->getTranslator())) {
+            $aDropdownOptions['label'] = $oTranslator->translate($aDropdownOptions['label'], $this->getTranslatorTextDomain());
+        }
 
-		//Role
-		if(empty($aDropdownOptions['toggle_attributes']['role']))$aDropdownOptions['toggle_attributes']['role'] = 'button';
+        /*
+         * Dropdown toggle attributes (class)
+         */
+        if (empty($aDropdownOptions['toggle_attributes'])) {
+            $aDropdownOptions['toggle_attributes'] = array('class' => 'sr-only dropdown-toggle');
+        } else {
+            if (!is_array($aDropdownOptions['toggle_attributes'])) {
+                throw new InvalidArgumentException('"toggle_attributes" option expects an array, "' . gettype($aDropdownOptions['toggle_attributes']) . '" given');
+            }
+            
+            if (empty($aDropdownOptions['toggle_attributes']['class'])) {
+                $aDropdownOptions['toggle_attributes']['class'] = 'sr-only dropdown-toggle';
+            } else {
+                if (!preg_match('/(\s|^)sr-only(\s|$)/', $aDropdownOptions['toggle_attributes']['class'])) {
+                    $aDropdownOptions['toggle_attributes']['class'] .= ' sr-only';
+                }
+                if (!preg_match('/(\s|^)dropdown-toggle(\s|$)/', $aDropdownOptions['toggle_attributes']['class'])) {
+                    $aDropdownOptions['toggle_attributes']['class'] .= ' dropdown-toggle';
+                }
+            }
+        }
 
-		//Href
-		if(empty($aDropdownOptions['toggle_attributes']['href']))$aDropdownOptions['toggle_attributes']['href'] = '#';
+        /*
+         * Dropdown toggle attributes (data-toggle)
+         */
+        if (empty($aDropdownOptions['toggle_attributes']['data-toggle'])) {
+            $aDropdownOptions['toggle_attributes']['data-toggle'] = 'dropdown';
+        }
 
-		//Id
-		if(!empty($aDropdownOptions['name']))$aDropdownOptions['toggle_attributes']['id'] = $aDropdownOptions['name'];
+        /*
+         * Dropdown toggle attributes (role)
+         */
+        if (empty($aDropdownOptions['toggle_attributes']['role'])) {
+            $aDropdownOptions['toggle_attributes']['role'] = 'button';
+        }
 
-		$aValidTagAttributes = $this->validTagAttributes;
-		$this->validTagAttributes = array('href' => true);
-		$sAttributeString = $this->createAttributesString($aDropdownOptions['toggle_attributes']);
-		$this->validTagAttributes = $aValidTagAttributes;
+        /*
+         * Dropdown toggle attributes (href)
+         */
+        if (empty($aDropdownOptions['toggle_attributes']['href'])) {
+            $aDropdownOptions['toggle_attributes']['href'] = '#';
+        }
 
-		return sprintf(
-			self::$dropdownToggleFormat,
-			//Toggle attributes
-			$sAttributeString,
-			//Toggle label
-			$this->getEscapeHtmlHelper()->__invoke($aDropdownOptions['label'])
-		);
-	}
+        /*
+         * Dropdown toggle attributes (id)
+         */
+        if (!empty($aDropdownOptions['name'])) {
+            $aDropdownOptions['toggle_attributes']['id'] = $aDropdownOptions['name'];
+        }
 
-	/**
-	 * Render dropdown list items markup
-	 * @param array $aDropdownOptions
-	 * @throws \LogicException
-	 * @return string
-	 */
-	public function renderListItems(array $aDropdownOptions){
-		if(!isset($aDropdownOptions['items']))throw new \LogicException(__METHOD__.' expects "items" option');
-		if(!is_array($aDropdownOptions['items']))throw new \LogicException('"items" option expects an array, "'.gettype($aDropdownOptions['items']).'" given');
+        $aValidTagAttributes = $this->validTagAttributes;
+        $this->validTagAttributes = array('href' => true);
+        $sAttributeString = $this->createAttributesString($aDropdownOptions['toggle_attributes']);
+        $this->validTagAttributes = $aValidTagAttributes;
+
+        return sprintf(
+            self::$dropdownToggleFormat,
+            $sAttributeString, //Toggle attributes
+            $this->getEscapeHtmlHelper()->__invoke($aDropdownOptions['label']) //Toggle label
+        );
+    }
+
+    /**
+     * Render dropdown list items markup
+     * @param array $aDropdownOptions
+     * @throws LogicException
+     * @return string
+     */
+    public function renderListItems(array $aDropdownOptions)
+    {
+        if (!isset($aDropdownOptions['items'])) {
+            throw new LogicException(__METHOD__ . ' expects "items" option');
+        }
+        
+        if (!is_array($aDropdownOptions['items'])) {
+            throw new LogicException('"items" option expects an array, "' . gettype($aDropdownOptions['items']) . '" given');
+        }
+
+        /*
+         * Dropdown list attributes (class)
+         */
+        if (empty($aDropdownOptions['list_attributes'])) {
+            $aDropdownOptions['list_attributes'] = array('class' => 'dropdown-menu');
+        } else {
+            if (!is_array($aDropdownOptions['list_attributes'])) {
+                throw new \LogicException('"list_attributes" option expects an array, "' . gettype($aDropdownOptions['list_attributes']) . '" given');
+            }
+            
+            if (empty($aDropdownOptions['list_attributes']['class'])) {
+                $aDropdownOptions['list_attributes']['class'] = 'dropdown-menu';
+            } elseif (!preg_match('/(\s|^)dropdown-menu(\s|$)/', $aDropdownOptions['list_attributes']['class'])) {
+                $aDropdownOptions['list_attributes']['class'] .= ' dropdown-menu';
+            }
+        }
+
+        /*
+         * Dropdown list attributes (role)
+         */
+        if (empty($aDropdownOptions['list_attributes']['role'])) {
+            $aDropdownOptions['list_attributes']['role'] = 'menu';
+        }
+
+        /*
+         * Dropdown list attributes (name)
+         */
+        if (!empty($aDropdownOptions['name'])) {
+            $aDropdownOptions['list_attributes']['aria-labelledby'] = $aDropdownOptions['name'];
+        }
+
+        /*
+         * Dropdown list attributes (items)
+         */
+        $sItems = '';
+        foreach ($aDropdownOptions['items'] as $sKey => $aItemOptions) {
+            if (!is_array($aItemOptions)) {
+                if (!is_scalar($aItemOptions)) {
+                    throw new \LogicException('item option expects an array or a scalar value, "' . gettype($aItemOptions) . '" given');
+                }
+                $aItemOptions = $aItemOptions === self::TYPE_ITEM_DIVIDER
+                    //Divider
+                    ? array('type' => self::TYPE_ITEM_DIVIDER)
+                    //Link
+                    : array(
+                    'label' => $aItemOptions,
+                    'type' => self::TYPE_ITEM_LINK,
+                    'item_attributes' => array('href' => is_string($sKey) ? $sKey : null)
+                );
+            } else {
+                if (!isset($aItemOptions['label'])) {
+                    $aItemOptions['label'] = is_string($sKey) ? $sKey : null;
+                }
+                
+                if (!isset($aItemOptions['type'])) {
+                    $aItemOptions['type'] = self::TYPE_ITEM_LINK;
+                }
+            }
+            $sItems .= $this->renderItem($aItemOptions) . PHP_EOL;
+        }
+
+        return sprintf(
+            self::$dropdownListFormat,
+            $this->createAttributesString($aDropdownOptions['list_attributes']), // List attributes
+            $sItems // Items
+        );
+    }
+
+    /**
+     * Render dropdown list item markup
+     * @param array $aItemOptions
+     * @throws LogicException
+     * @return string
+     */
+    protected function renderItem($aItemOptions)
+    {
+        if (empty($aItemOptions['type'])) {
+            throw new \LogicException(__METHOD__ . ' expects "type" option');
+        }
 
 
-		// ### Dropdown list attributes ###
+        /*
+         * Item container attributes
+         */
+        if (empty($aItemOptions['attributes'])) {
+            $aItemOptions['attributes'] = array();
+        } elseif (!is_array($aItemOptions['attributes'])) {
+            throw new \LogicException('"attributes" option expects an array, "' . gettype($aItemOptions['attributes']) . '" given');
+        }
 
-		//Class
-		if(empty($aDropdownOptions['list_attributes']))$aDropdownOptions['list_attributes'] = array('class' => 'dropdown-menu');
-		else{
-			if(!is_array($aDropdownOptions['list_attributes']))throw new \LogicException('"list_attributes" option expects an array, "'.gettype($aDropdownOptions['list_attributes']).'" given');
-			if(empty($aDropdownOptions['list_attributes']['class']))$aDropdownOptions['list_attributes']['class'] = 'dropdown-menu';
-			elseif(!preg_match('/(\s|^)dropdown-menu(\s|$)/',$aDropdownOptions['list_attributes']['class']))$aDropdownOptions['list_attributes']['class'] .= ' dropdown-menu';
-		}
+        /*
+         * Item container attributes (role)
+         */
+        if (empty($aItemOptions['attributes']['role'])) {
+            $aItemOptions['attributes']['role'] = 'presentation';
+        }
 
-		//Role
-		if(empty($aDropdownOptions['list_attributes']['role']))$aDropdownOptions['list_attributes']['role'] = 'menu';
+        $sItemContent = '';
+        switch ($aItemOptions['type']) {
+            case self::TYPE_ITEM_HEADER:
+                /*
+                 * Define item container "header" class
+                 */
+                if (empty($aItemOptions['attributes']['class'])) {
+                    $aItemOptions['attributes']['class'] = 'dropdown-header';
+                } elseif (!preg_match('/(\s|^)dropdown-header(\s|$)/', $aItemOptions['attributes']['class'])) {
+                    $aItemOptions['attributes']['class'] .= ' dropdown-header';
+                }
 
+                /*
+                 * Header label
+                 */
+                if (empty($aItemOptions['label'])) {
+                    throw new \LogicException('"' . $aItemOptions['type'] . '" item expects "label" option');
+                }
+                
+                if (!is_scalar($aItemOptions['label'])) {
+                    throw new \LogicException('"label" option expect scalar value, "' . gettype($aItemOptions['label']) . '" given');
+                } elseif (($oTranslator = $this->getTranslator())) {
+                    $aItemOptions['label'] = $oTranslator->translate($aItemOptions['label'], $this->getTranslatorTextDomain());
+                }
 
-		//Id
-		if(!empty($aDropdownOptions['name']))$aDropdownOptions['list_attributes']['aria-labelledby'] = $aDropdownOptions['name'];
+                $sItemContent = $this->getEscapeHtmlHelper()->__invoke($aItemOptions['label']);
+                break;
+            case self::TYPE_ITEM_DIVIDER:
+                /*
+                 * Define item container "divider" class
+                 */
+                if (empty($aItemOptions['attributes']['class'])) {
+                    $aItemOptions['attributes']['class'] = 'divider';
+                } elseif (!preg_match('/(\s|^)divider(\s|$)/', $aItemOptions['attributes']['class']))
+                    $aItemOptions['attributes']['class'] .= ' divider';
 
-		// ### Items ###
+                $sItemContent = '';
+                break;
 
-		$sItems = '';
-		foreach($aDropdownOptions['items'] as $sKey => $aItemOptions){
-			if(!is_array($aItemOptions)){
-				if(!is_scalar($aItemOptions))throw new \LogicException('item option expects an array or a scalar value, "'.gettype($aItemOptions).'" given');
-				$aItemOptions = $aItemOptions === self::TYPE_ITEM_DIVIDER
-				//Divider
-				?array('type' => self::TYPE_ITEM_DIVIDER)
-				//Link
-				:array(
-					'label' => $aItemOptions,
-					'type' => self::TYPE_ITEM_LINK,
-					'item_attributes' => array('href' => is_string($sKey)?$sKey:null)
-				);
-			}
-			else{
-				if(!isset($aItemOptions['label']))$aItemOptions['label'] = is_string($sKey)?$sKey:null;
-				if(!isset($aItemOptions['type']))$aItemOptions['type'] = self::TYPE_ITEM_LINK;
-			}
-			$sItems .= $this->renderItem($aItemOptions).PHP_EOL;
-		}
+            case self::TYPE_ITEM_LINK:
+                if (empty($aItemOptions['label'])) {
+                    throw new \LogicException('"' . $aItemOptions['type'] . '" item expects "label" option');
+                }
+                if (!is_scalar($aItemOptions['label'])) {
+                    throw new \LogicException('"label" option expect scalar value, "' . gettype($aItemOptions['label']) . '" given');
+                } elseif (($oTranslator = $this->getTranslator())) {
+                    $aItemOptions['label'] = $oTranslator->translate($aItemOptions['label'], $this->getTranslatorTextDomain());
+                }
 
-		return sprintf(
-			self::$dropdownListFormat,
-			//List attributes
-			$this->createAttributesString($aDropdownOptions['list_attributes']),
-			//Items
-			$sItems
-		);
-	}
+                /*
+                 * Item attributes (Role)
+                 */
+                if (empty($aItemOptions['item_attributes']['role'])) {
+                    $aItemOptions['item_attributes']['role'] = 'menuitem';
+                }
 
-	/**
-	 * Render dropdown list item markup
-	 * @param array $aItemOptions
-	 * @throws \LogicException
-	 * @return string
-	 */
-	protected function renderItem($aItemOptions){
-		if(empty($aItemOptions['type']))throw new \LogicException(__METHOD__.' expects "type" option');
+                /*
+                 * Item attributes (Tab index)
+                 */
+                if (!isset($aItemOptions['item_attributes']['tabindex'])) {
+                    $aItemOptions['item_attributes']['tabindex'] = '-1';
+                }
 
+                /*
+                 * Item attributes (Href)
+                 */
+                if (!isset($aItemOptions['item_attributes']['href'])) {
+                    $aItemOptions['item_attributes']['href'] = '#';
+                }
 
-		//Item container attributes
-		if(empty($aItemOptions['attributes']))$aItemOptions['attributes'] = array();
-		elseif(!is_array($aItemOptions['attributes']))throw new \LogicException('"attributes" option expects an array, "'.gettype($aItemOptions['attributes']).'" given');
+                $aValidTagAttributes = $this->validTagAttributes;
+                $this->validTagAttributes = array('href' => true);
+                $sAttributeString = $this->createAttributesString($aItemOptions['item_attributes']);
+                $this->validTagAttributes = $aValidTagAttributes;
 
-		//Role
-		if(empty($aItemOptions['attributes']['role']))$aItemOptions['attributes']['role'] = 'presentation';
+                $sItemContent = sprintf(
+                    self::$dropdownItemFormats[self::TYPE_ITEM_LINK],
+                    $sAttributeString,
+                    $this->getEscapeHtmlHelper()->__invoke($aItemOptions['label'])
+                );
+                break;
+        }
 
-		$sItemContent = '';
-		switch($aItemOptions['type']){
-			case self::TYPE_ITEM_HEADER:
-				//Define item container "header" class
-				if(empty($aItemOptions['attributes']['class']))$aItemOptions['attributes']['class'] = 'dropdown-header';
-				elseif(!preg_match('/(\s|^)dropdown-header(\s|$)/',$aItemOptions['attributes']['class']))$aItemOptions['attributes']['class'] .= ' dropdown-header';
-
-				//Header label
-				if(empty($aItemOptions['label']))throw new \LogicException('"'.$aItemOptions['type'].'" item expects "label" option');
-				if(!is_scalar($aItemOptions['label']))throw new \LogicException('"label" option expect scalar value, "'.gettype($aItemOptions['label']).'" given');
-				elseif(($oTranslator = $this->getTranslator()))$aItemOptions['label'] = $oTranslator->translate($aItemOptions['label'],$this->getTranslatorTextDomain());
-
-				$sItemContent = $this->getEscapeHtmlHelper()->__invoke($aItemOptions['label']);
-				break;
-			case self::TYPE_ITEM_DIVIDER:
-				//Define item container "divider" class
-				if(empty($aItemOptions['attributes']['class']))$aItemOptions['attributes']['class'] = 'divider';
-				elseif(!preg_match('/(\s|^)divider(\s|$)/',$aItemOptions['attributes']['class']))$aItemOptions['attributes']['class'] .= ' divider';
-
-				$sItemContent = '';
-				break;
-
-			case self::TYPE_ITEM_LINK:
-				if(empty($aItemOptions['label']))throw new \LogicException('"'.$aItemOptions['type'].'" item expects "label" option');
-				if(!is_scalar($aItemOptions['label']))throw new \LogicException('"label" option expect scalar value, "'.gettype($aItemOptions['label']).'" given');
-				elseif(($oTranslator = $this->getTranslator()))$aItemOptions['label'] = $oTranslator->translate($aItemOptions['label'],$this->getTranslatorTextDomain());
-
-				//Item attributes
-
-				//Role
-				if(empty($aItemOptions['item_attributes']['role']))$aItemOptions['item_attributes']['role'] = 'menuitem';
-
-				//Tab index
-				if(!isset($aItemOptions['item_attributes']['tabindex']))$aItemOptions['item_attributes']['tabindex'] = '-1';
-
-				//Href
-				if(!isset($aItemOptions['item_attributes']['href']))$aItemOptions['item_attributes']['href'] = '#';
-
-				$aValidTagAttributes = $this->validTagAttributes;
-				$this->validTagAttributes = array('href' => true);
-				$sAttributeString = $this->createAttributesString($aItemOptions['item_attributes']);
-				$this->validTagAttributes = $aValidTagAttributes;
-
-				$sItemContent = sprintf(
-					self::$dropdownItemFormats[self::TYPE_ITEM_LINK],
-					$sAttributeString,
-					$this->getEscapeHtmlHelper()->__invoke($aItemOptions['label'])
-				);
-				break;
-		}
-
-		return sprintf(
-			self::$dropdownItemContainerFormat,
-			$this->createAttributesString($aItemOptions['attributes']),
-			$sItemContent
-		);
-	}
+        return sprintf(
+            self::$dropdownItemContainerFormat,
+            $this->createAttributesString($aItemOptions['attributes']),
+            $sItemContent
+        );
+    }
 }

--- a/src/TwbBundle/View/Helper/TwbBundleFontAwesome.php
+++ b/src/TwbBundle/View/Helper/TwbBundleFontAwesome.php
@@ -7,6 +7,7 @@
 
 namespace TwbBundle\View\Helper;
 
+use InvalidArgumentException;
 use Zend\Form\View\Helper\AbstractHelper;
 
 /**
@@ -24,7 +25,7 @@ class TwbBundleFontAwesome extends AbstractHelper
      * Invoke helper as functor, proxies to {@link render()}.
      * @param string $sFontAwesome
      * @param array $aFontAwesomeAttributes : [optionnal]
-     * @return string|\TwbBundle\View\Helper\TwbBundleFontAwesome
+     * @return string|TwbBundleFontAwesome
      */
     public function __invoke($sFontAwesome = null, array $aFontAwesomeAttributes = null)
     {
@@ -38,7 +39,7 @@ class TwbBundleFontAwesome extends AbstractHelper
      * Retrieve fontAwesome markup
      * @param string $sFontAwesome
      * @param  array $aFontAwesomeAttributes : [optionnal]
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return string
      */
     public function render($sFontAwesome, array $aFontAwesomeAttributes = null)
@@ -76,4 +77,4 @@ class TwbBundleFontAwesome extends AbstractHelper
             $this->createAttributesString($aFontAwesomeAttributes)
         );
     }
-} 
+}

--- a/src/TwbBundle/View/Helper/TwbBundleGlyphicon.php
+++ b/src/TwbBundle/View/Helper/TwbBundleGlyphicon.php
@@ -1,34 +1,42 @@
 <?php
-namespace TwbBundle\View\Helper;
-class TwbBundleGlyphicon extends \Zend\Form\View\Helper\AbstractHelper{
-	/**
-	 * @var string
-	 */
-	private static $glyphiconFormat = '<span %s></span>';
 
-	/**
-	 * Invoke helper as functor, proxies to {@link render()}.
-	 * @param string $sGlyphicon
-	 * @param array $aGlyphiconAttributes : [optionnal]
-	 * @return string|\TwbBundle\View\Helper\TwbBundleGlyphicon
-	 */
-    public function __invoke($sGlyphicon = null, array $aGlyphiconAttributes = null){
+namespace TwbBundle\View\Helper;
+
+use InvalidArgumentException;
+use Zend\Form\View\Helper\AbstractHelper;
+
+class TwbBundleGlyphicon extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    private static $glyphiconFormat = '<span %s></span>';
+
+    /**
+     * Invoke helper as functor, proxies to {@link render()}.
+     * @param string $sGlyphicon
+     * @param array $aGlyphiconAttributes : [optionnal]
+     * @return string|TwbBundleGlyphicon
+     */
+    public function __invoke($sGlyphicon = null, array $aGlyphiconAttributes = null)
+    {
         if (!$sGlyphicon) {
             return $this;
         }
-        return $this->render($sGlyphicon,$aGlyphiconAttributes);
+        return $this->render($sGlyphicon, $aGlyphiconAttributes);
     }
 
     /**
      * Retrieve glyphicon markup
      * @param string $sGlyphicon
      * @param  array $aGlyphiconAttributes : [optionnal]
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return string
      */
-	public function render($sGlyphicon,array $aGlyphiconAttributes = null){
-		if (!is_scalar($sGlyphicon)) {
-            throw new \InvalidArgumentException('Glyphicon expects a scalar value, "' . gettype($sGlyphicon) . '" given');
+    public function render($sGlyphicon, array $aGlyphiconAttributes = null)
+    {
+        if (!is_scalar($sGlyphicon)) {
+            throw new InvalidArgumentException('Glyphicon expects a scalar value, "' . gettype($sGlyphicon) . '" given');
         }
 
         if (empty($aGlyphiconAttributes)) {
@@ -42,17 +50,17 @@ class TwbBundleGlyphicon extends \Zend\Form\View\Helper\AbstractHelper{
             }
         }
 
-        if(strpos('glyphicon-', $sGlyphicon) !== 0) {
-            $sGlyphicon = 'glyphicon-'.$sGlyphicon;
+        if (strpos('glyphicon-', $sGlyphicon) !== 0) {
+            $sGlyphicon = 'glyphicon-' . $sGlyphicon;
         }
 
-        if (!preg_match('/(\s|^)'.  preg_quote($sGlyphicon, '/').'(\s|$)/', $aGlyphiconAttributes['class'])) {
-            $aGlyphiconAttributes['class'] .= ' '.$sGlyphicon;
+        if (!preg_match('/(\s|^)' . preg_quote($sGlyphicon, '/') . '(\s|$)/', $aGlyphiconAttributes['class'])) {
+            $aGlyphiconAttributes['class'] .= ' ' . $sGlyphicon;
         }
 
         return sprintf(
-			self::$glyphiconFormat,
-			$this->createAttributesString($aGlyphiconAttributes)
-		);
-	}
+            self::$glyphiconFormat,
+            $this->createAttributesString($aGlyphiconAttributes)
+        );
+    }
 }

--- a/src/TwbBundle/View/Helper/TwbBundleLabel.php
+++ b/src/TwbBundle/View/Helper/TwbBundleLabel.php
@@ -1,10 +1,16 @@
 <?php
+
 namespace TwbBundle\View\Helper;
-class TwbBundleLabel extends \Zend\Form\View\Helper\AbstractHelper{
-	/**
-	 * @var string
-	 */
-	private static $labelFormat = '<%s %s>%s</%1$s>';
+
+use InvalidArgumentException;
+use Zend\Form\View\Helper\AbstractHelper;
+
+class TwbBundleLabel extends AbstractHelper
+{
+    /**
+     * @var string
+     */
+    private static $labelFormat = '<%s %s>%s</%1$s>';
 
     /**
      * @var string
@@ -18,40 +24,61 @@ class TwbBundleLabel extends \Zend\Form\View\Helper\AbstractHelper{
         'href' => true,
     );
 
-	/**
-	 * Invoke helper as functor, proxies to {@link render()}.
-	 * @param string $sLabelMessage
-	 * @param string|array $aLabelAttributes : [optionnal] if string, label class
-	 * @return string|\TwbBundle\View\Helper\TwbBundleAlert
-	 */
-    public function __invoke($sLabelMessage = null, $aLabelAttributes = 'label-default'){
-        if(!$sLabelMessage)return $this;
-        return $this->render($sLabelMessage,$aLabelAttributes);
+    /**
+     * Invoke helper as functor, proxies to {@link render()}.
+     * @param string $sLabelMessage
+     * @param string|array $aLabelAttributes : [optionnal] if string, label class
+     * @return string|\TwbBundle\View\Helper\TwbBundleAlert
+     */
+    public function __invoke($sLabelMessage = null, $aLabelAttributes = 'label-default')
+    {
+        if (!$sLabelMessage) {
+            return $this;
+        }
+        
+        return $this->render($sLabelMessage, $aLabelAttributes);
     }
 
     /**
      * Retrieve label markup
      * @param string $sLabelMessage
      * @param  string|array $aLabelAttributes : [optionnal] if string, label class
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return string
      */
-	public function render($sLabelMessage, $aLabelAttributes = 'label-default'){
-		if(!is_scalar($sLabelMessage))throw new \InvalidArgumentException('Label message expects a scalar value, "'.gettype($sLabelMessage).'" given');
-		if(empty($aLabelAttributes))throw new \InvalidArgumentException('Label attributes are empty');
-		if(is_string($aLabelAttributes))$aLabelAttributes = array('class' => $aLabelAttributes);
-		elseif(!is_array($aLabelAttributes))throw new \InvalidArgumentException('Label attributes expects a string or an array, "'.gettype($aLabelAttributes).'" given');
-		elseif(empty($aLabelAttributes['class']))throw new \InvalidArgumentException('Label "class" attribute is empty');
-		elseif(!is_string($aLabelAttributes['class']))throw new \InvalidArgumentException('Label "class" attribute expects string, "'.gettype($aLabelAttributes).'" given');
+    public function render($sLabelMessage, $aLabelAttributes = 'label-default')
+    {
+        if (!is_scalar($sLabelMessage)) {
+            throw new InvalidArgumentException('Label message expects a scalar value, "' . gettype($sLabelMessage) . '" given');
+        }
 
+        if (empty($aLabelAttributes)) {
+            throw new InvalidArgumentException('Label attributes are empty');
+        }
 
-		if(!preg_match('/(\s|^)label(\s|$)/',$aLabelAttributes['class']))$aLabelAttributes['class'] .= ' label';
-		if(null !== ($oTranslator = $this->getTranslator()))$sLabelMessage = $oTranslator->translate($sLabelMessage, $this->getTranslatorTextDomain());
-		return sprintf(
-			self::$labelFormat,
-            isset($aLabelAttributes['tagName'])?$aLabelAttributes['tagName']:$this->tagName,
-			$this->createAttributesString($aLabelAttributes),
-			$sLabelMessage
-		);
-	}
+        if (is_string($aLabelAttributes)) {
+            $aLabelAttributes = array('class' => $aLabelAttributes);
+        } elseif (!is_array($aLabelAttributes)) {
+            throw new InvalidArgumentException('Label attributes expects a string or an array, "' . gettype($aLabelAttributes) . '" given');
+        } elseif (empty($aLabelAttributes['class'])) {
+            throw new \InvalidArgumentException('Label "class" attribute is empty');
+        } elseif (!is_string($aLabelAttributes['class'])) {
+            throw new InvalidArgumentException('Label "class" attribute expects string, "' . gettype($aLabelAttributes) . '" given');
+        }
+
+        if (!preg_match('/(\s|^)label(\s|$)/', $aLabelAttributes['class'])) {
+            $aLabelAttributes['class'] .= ' label';
+        }
+
+        if (null !== ($oTranslator = $this->getTranslator())) {
+            $sLabelMessage = $oTranslator->translate($sLabelMessage, $this->getTranslatorTextDomain());
+        }
+
+        return sprintf(
+            self::$labelFormat,
+            isset($aLabelAttributes['tagName']) ? $aLabelAttributes['tagName'] : $this->tagName,
+            $this->createAttributesString($aLabelAttributes),
+            $sLabelMessage
+        );
+    }
 }


### PR DESCRIPTION
Ignore custom view helpers by adding the following to the config

```
return [
    'twbbundle' => [
        'ignoredViewHelpers' => [
            'viewhelpername'
        ]
    ]
];
```

plus update coding style to pass psr-2 php code sniffer validation
