### PR TITLE
Update TwbBundleFormElement.php

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
@@ -163,7 +163,7 @@ class TwbBundleFormElement extends \Zend\Form\View\Helper\FormElement implements
      * @param string $sTextDomain : [optional] text domain Default is null, which skips setTranslatorTextDomain
      * @return \TwbBundle\Form\View\Helper\TwbBundleFormElement
      */
-    public function setTranslator(\Zend\I18n\Translator\TranslatorInterface $oTranslator = null, $sTextDomain = null) {
+    public function setTranslator(\Zend\I18n\Translator\Translator $oTranslator = null, $sTextDomain = null) {
         $this->translator = $oTranslator;
         if (null !== $sTextDomain) {
             $this->setTranslatorTextDomain($sTextDomain);


### PR DESCRIPTION
Declaration of TwbBundle\Form\View\Helper\TwbBundleFormElement::setTranslator() must be compatible with Zend\I18n\Translator\TranslatorAwareInterface::setTranslator(Zend\I18n\Translator\Translator $translator = NULL, $textDomain = NULL)
