### PR TITLE
removed @stable flags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,22 +22,22 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "zendframework/zend-config": "2.3.*@stable",
-        "zendframework/zend-escaper": "2.3.*@stable",
-        "zendframework/zend-form": "2.3.*@stable",
-        "zendframework/zend-i18n": "2.3.*@stable",
-        "zendframework/zend-loader": "2.3.*@stable",
-        "zendframework/zend-log": "2.3.*@stable",
-        "zendframework/zend-modulemanager": "2.3.*@stable",
-        "zendframework/zend-mvc": "2.3.*@stable",
-        "zendframework/zend-serializer": "2.3.*@stable",
-        "zendframework/zend-servicemanager": "2.3.*@stable",
-        "zendframework/zend-stdlib": "2.3.*@stable",
-        "zendframework/zend-view": "2.3.*@stable"
+        "zendframework/zend-config": "2.3.*",
+        "zendframework/zend-escaper": "2.3.*",
+        "zendframework/zend-form": "2.3.*",
+        "zendframework/zend-i18n": "2.3.*",
+        "zendframework/zend-loader": "2.3.*",
+        "zendframework/zend-log": "2.3.*",
+        "zendframework/zend-modulemanager": "2.3.*",
+        "zendframework/zend-mvc": "2.3.*",
+        "zendframework/zend-serializer": "2.3.*",
+        "zendframework/zend-servicemanager": "2.3.*",
+        "zendframework/zend-stdlib": "2.3.*",
+        "zendframework/zend-view": "2.3.*"
     },
     "require-dev": {
-    	"phpunit/phpunit": "4.*@stable",
-    	"satooshi/php-coveralls": "0.*@stable"
+    	"phpunit/phpunit": "4.*",
+    	"satooshi/php-coveralls": "0.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hi,
according to https://getcomposer.org/doc/04-schema.md#package-links you don't needed all these @stable flags, cause you already configured "minimum-stability" to "stable".

At first glance it seems to be just cosmetic, but thoose flags makes it impossible to use a forked version of zend framework.