### PR TITLE
Group elements in a row

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ The option `validation-state` (string) can be passed to the element to render th
 The option `column-size` (int) can be passed to the element to render the row with a defined column size class attribute(`col-lg-...`).
 The option `help-block` (string) can be passed to the element to render an help block translated appending the element.
 
+If you like to wrap elements into a <div class="row"> in case you want X number of elements on the same line the option `twb-row-open` (bool) can be passed to the element where the row must start and will be printed before the element is rendered. It could be you have to provide the `column-size` in combination with this option.
+The option `twb-row-close` (bool) can be passed to the element to close the earlier opened row and will be printed after the elements is rendered.
+Note: closing earlier opened rows is your responsibility.
+
 You can allow the label html rendering after toggling off escape :
 
 ```php

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormCollection.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormCollection.php
@@ -11,12 +11,12 @@ class TwbBundleFormCollection extends FormCollection
     /**
      * @var string
      */
-    private static $legendFormat = '<legend%s>%s</legend>';
+    protected static $legendFormat = '<legend%s>%s</legend>';
 
     /**
      * @var string
      */
-    private static $fieldsetFormat = '<fieldset%s>%s</fieldset>';
+    protected static $fieldsetFormat = '<fieldset%s>%s</fieldset>';
 
     /**
      * Attributes valid for the tag represented by this helper
@@ -65,7 +65,7 @@ class TwbBundleFormCollection extends FormCollection
         }
 
         if ($bShouldWrap) {
-            if (($sLabel = $oElement->getLabel())) {
+            if (false != ($sLabel = $oElement->getLabel())) {
                 if (null !== ($oTranslator = $this->getTranslator())) {
                     $sLabel = $oTranslator->translate($sLabel, $this->getTranslatorTextDomain());
                 }
@@ -78,7 +78,7 @@ class TwbBundleFormCollection extends FormCollection
             //Set form layout class
             if ($sElementLayout) {
                 $sLayoutClass = 'form-' . $sElementLayout;
-                if ($sElementClass = $oElement->getAttribute('class')) {
+                if (false != ($sElementClass = $oElement->getAttribute('class'))) {
                     if (!preg_match('/(\s|^)' . preg_quote($sLayoutClass, '/') . '(\s|$)/', $sElementClass)) {
                         $oElement->setAttribute('class', trim($sElementClass . ' ' . $sLayoutClass));
                     }
@@ -102,7 +102,7 @@ class TwbBundleFormCollection extends FormCollection
      */
     public function renderTemplate(CollectionElement $collection)
     {
-        if ($sElementLayout = $collection->getOption('twb-layout')) {
+        if (false != ($sElementLayout = $collection->getOption('twb-layout'))) {
             $elementOrFieldset = $collection->getTemplateElement();
             $elementOrFieldset->setOption('twb-layout', $sElementLayout);
         }

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormCollection.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormCollection.php
@@ -56,7 +56,15 @@ class TwbBundleFormCollection extends FormCollection
                 if ($oElementOrFieldset instanceof \Zend\Form\FieldsetInterface) {
                     $sMarkup .= $oFieldsetHelper($oElementOrFieldset);
                 } elseif ($oElementOrFieldset instanceof \Zend\Form\ElementInterface) {
-                    $sMarkup .= $oElementHelper($oElementOrFieldset);
+                	if ($oElementOrFieldset->getOption('twb-row-open')) {
+						$sMarkup .= '<div class="row">' . PHP_EOL;
+					}
+
+					$sMarkup .= $oElementHelper($oElementOrFieldset);
+
+					if ($oElementOrFieldset->getOption('twb-row-close')) {
+						$sMarkup .= '</div>' . PHP_EOL;
+					}
                 }
             }
             if ($oElement instanceof \Zend\Form\Element\Collection && $oElement->shouldCreateTemplate()) {


### PR DESCRIPTION
Added feature for grouping elements within a single row without need of creating a customized template.
Also marked private properties as protected so the class can be extended more easily without needing to copy-paste the complete class.

My IDE (Zend Studio) was complaining about assignments in conditions so this is fixed as well.