### PR TITLE
Provide a means to set a complementary class on form-group wrappers

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -72,6 +72,10 @@ class TwbBundleFormRow extends FormRow
 
         $sRowClass = '';
 
+	    if( ($fgs = $oElement->getOption('twb-form-group-size' )) ) {
+		    $sRowClass = $fgs;
+	    }
+		    
         //Validation state
         if (($sValidationState = $oElement->getOption('validation-state'))) {
             $sRowClass .= ' has-' . $sValidationState;


### PR DESCRIPTION
Right now, there's no means to easily append classes such as form-group-sm to the form-group div sets that Twb creates.  This quick 2 liner lets us specify form-group class (e.g., twig):

```twig
{% for f in server_form %}
    {% do f.setOption( 'twb-form-group-size', 'form-group-sm' ) %}
    {{ formRow( f ) }}
{% endfor %}
```

The output is as expected:
```html
<div class="form-group form-group-sm">
    ...  
</div>
```

Thanks for considering this augmentation!