### PR TITLE
Attempting previous patch again, believe coverall was out to lunch!

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,17 @@ $this->formRow(new \Zend\Form\Element('my-element',  array(
 )));
 ```
 
+You can also set the the form-group size by passing the `twb-form-group-size` option on the element passed to formRow, example Twig syntax:
+
+```twig
+{% for f in server_form %}
+    {% do f.setOption( 'twb-form-group-size', 'form-group-sm' ) %}
+    {{ formRow( f ) }}
+{% endfor %}
+```
+
+
+
 #### Static : `TwbBundle\Form\View\Helper\TwbBundleFormStatic`
 
 Static helper can be called in a view with the view helper service `formStatic(\Zend\Form\ElementInterface $oElement)` :

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -71,6 +71,10 @@ class TwbBundleFormRow extends FormRow
         }
 
         $sRowClass = '';
+        
+        if( $fgs = $oElement->getOption('twb-form-group-size') ){
+            $sRowClass = $fgs;
+        }
 
         //Validation state
         if (($sValidationState = $oElement->getOption('validation-state'))) {


### PR DESCRIPTION
Right now, there's no means to easily append classes such as form-group-sm to the form-group div sets that Twb creates.  This quick 2 liner lets us specify form-group class (e.g., twig):

```twig
{% for f in server_form %}
    {% do f.setOption( 'twb-form-group-size', 'form-group-sm' ) %}
    {{ formRow( f ) }}
{% endfor %}
```

The output is as expected:
```html
<div class="form-group form-group-sm">
    ...  
</div>
```

Thanks for considering this augmentation!
