### PR TITLE
Use value attribute as label for submit buttons

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
@@ -94,7 +94,7 @@ class TwbBundleFormButton extends FormButton
                 'submit' === $oElement->getAttribute('type') &&
                 $oElement->hasAttribute('value')
             ) {
-                $sButtonContent = $oElement->getAttribute('value')
+                $sButtonContent = $oElement->getAttribute('value'),
             }
 
             if (null === $sButtonContent && !$aIconOptions) {

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
@@ -94,7 +94,7 @@ class TwbBundleFormButton extends FormButton
                 'submit' === $oElement->getAttribute('type') &&
                 $oElement->hasAttribute('value')
             ) {
-                $sButtonContent = $oElement->getAttribute('value'),
+                $sButtonContent = $oElement->getAttribute('value');
             }
 
             if (null === $sButtonContent && !$aIconOptions) {

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
@@ -88,6 +88,15 @@ class TwbBundleFormButton extends FormButton
          */
         if (null === $sButtonContent) {
             $sButtonContent = $oElement->getLabel();
+            if (
+                null === $sButtonContent &&
+                $oElement->hasAttribute('type') &&
+                'submit' === $oElement->getAttribute('type') &&
+                $oElement->hasAttribute('value')
+            ) {
+                $sButtonContent = $oElement->getAttribute('value')
+            }
+
             if (null === $sButtonContent && !$aIconOptions) {
                 throw new DomainException(sprintf(
                     '%s expects either button content as the second argument, ' .

--- a/tests/_files/expected-forms/basic-example.phtml
+++ b/tests/_files/expected-forms/basic-example.phtml
@@ -1,4 +1,4 @@
-<form action="" method="POST" role="form"><div class="form-group "><label for="exampleInputEmail1">Email address</label><input name="input-email" type="email" placeholder="Enter&#x20;email" id="exampleInputEmail1" class="form-control" value=""></div>
+<form method="POST" role="form"><div class="form-group "><label for="exampleInputEmail1">Email address</label><input name="input-email" type="email" placeholder="Enter&#x20;email" id="exampleInputEmail1" class="form-control" value=""></div>
 <div class="form-group "><label for="exampleInputPassword1">Password</label><input name="input-password" type="password" placeholder="Password" id="exampleInputPassword1" class="form-control" value=""></div>
 <div class="form-group "><label for="exampleInputFile">File input</label><input name="input-file" type="file" id="exampleInputFile"><p class="help-block">Example block-level help text here.</p></div>
 <div class="checkbox"><input type="hidden" name="input-checkbox" value="0"><label><input type="checkbox" name="input-checkbox" value="1"> Check me out</label></div>


### PR DESCRIPTION
Allows conversion from

```<input type="submit" value="Foo Bar">```
to
```<button type="submit" value="Foo Bar">Foo Bar</button>```


Example:
```
$formFactory->create(
	array(
		'spec' => array(
			'name' => 'submit',
			'type' => 'submit',
			'attributes' => array(
				'value' => 'Submit changes',
			),
		),
	)
);
```