### PR TITLE
Fix bug using twb-row-open and column-size options inside a form without fieldset

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
@@ -61,9 +61,14 @@ class TwbBundleForm extends Form
         $bHasColumnSizes = false;
         $sFormContent = '';
         $oRenderer = $this->getView();
+		$rowsOpened = 0;
         foreach ($oForm as $oElement) {
             $aOptions = $oElement->getOptions();
-            if (!$bHasColumnSizes && !empty($aOptions['column-size'])) {
+			if (isset($aOptions['twb-row-open']) && $aOptions['twb-row-open']) {
+			    $sFormContent .= '<div class="row">';
+			    $rowsOpened++;
+			}
+            if (!$bHasColumnSizes && !empty($aOptions['column-size']) && $rowsOpened === 0) {
                 $bHasColumnSizes = true;
             }
             //Define layout option to form elements if not already defined
@@ -72,6 +77,10 @@ class TwbBundleForm extends Form
                 $oElement->setOptions($aOptions);
             }
             $sFormContent .= $oElement instanceof FieldsetInterface ? $oRenderer->formCollection($oElement) : $oRenderer->formRow($oElement);
+			if (isset($aOptions['twb-row-close']) && $aOptions['twb-row-close']) {
+			    $sFormContent .= '</div>';
+			    $rowsOpened--;
+			}
         }
         if ($bHasColumnSizes && $sFormLayout !== self::LAYOUT_HORIZONTAL) {
             $sFormContent = sprintf(self::$formRowFormat, $sFormContent);


### PR DESCRIPTION
If i have the following entity (it's simplify)
```php
class Entity {

	protected $name;

	/**
	 * @Form\Options({
	 *		"twb-row-open"	: true,
	 *		"column-size"	: "md-4"
	 * })
	 */
	protected $start;

	/**
	 * @Form\Options({
	 *		"column-size"	: "md-4"
	 * })
	 *
	 */
	protected $end;

	/**
	 * @Form\Options({
	 *		"twb-row-close"	: true,
	 *		"column-size"	: "md-4"
	 * })
	 */
	protected $count;

	protected $type;
}
```
The form rendered is (it's simplify)
```html
<form>
    <div class="row">
        <div class="form-group">
              <label>Name</label>
              <input name="name" class="form-control" value="" type="text">
        </div>
        <div class="form-group  col-md-4">
              <label>Start</label>
              <input name="start" class="form-control" value="" type="date">
          </div>
          ....
    </div>
</form>
```
With the fix, now it's rendering like this:

```html
<form>
    <div class="form-group">
             <label>Name</label>
             <input name="name" class="form-control" value="" type="text">
    </div>
    <div class="row">
        <div class="form-group  col-md-4">
                <label>Start</label>
                <input name="start" class="form-control" value="" type="date">
          </div>
          ....
    </div>
      ....
</form>
```