### PR TITLE
Fixes usage of label option on button elements.

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormButton.php
@@ -87,10 +87,10 @@ class TwbBundleFormButton extends FormButton
          * Define button content
          */
         if (null === $sButtonContent) {
-            $sButtonContent = $oElement->getValue();
+            $sButtonContent = $oElement->getLabel();
 
             if (!$sButtonContent) {
-                $sButtonContent = $oElement->getLabel();
+                $sButtonContent = $oElement->getValue();
             }
 
             if (null === $sButtonContent && !$aIconOptions) {


### PR DESCRIPTION
The change from #139 broke all our buttons in an internal application because as soon as a value is set it is impossible to use a label. This pull request does allow the usage of the label option again.