### PR TITLE
button addon should always be wraped in a div element

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormElement.php
@@ -189,12 +189,10 @@ class TwbBundleFormElement extends FormElement implements TranslatorAwareInterfa
             
             $sMarkup .= $this->render($aAddOnOptions['element']);
 
+            //Element is a button, so add-on container must be a "div"
             if ($aAddOnOptions['element'] instanceof Button) {
                 $sAddonClass .= ' input-group-btn';
-                //Element contains dropdown, so add-on container must be a "div"
-                if ($aAddOnOptions['element']->getOption('dropdown')) {
-                    $sAddonTagName = 'div';
-                }
+                $sAddonTagName = 'div';
             } else {
                 $sAddonClass .= ' input-group-addon';
             }

--- a/tests/_files/expected-dropdowns/alignment.phtml
+++ b/tests/_files/expected-dropdowns/alignment.phtml
@@ -1,4 +1,4 @@
-<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul class="pull-right&#x20;dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
+<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul aria-labelledby="dropdownMenu1" class="pull-right&#x20;dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>
 <li role="presentation" class="divider"></li>

--- a/tests/_files/expected-dropdowns/disabled.phtml
+++ b/tests/_files/expected-dropdowns/disabled.phtml
@@ -1,4 +1,4 @@
-<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Regular link</a></li>
+<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Regular link</a></li>
 <li class="disabled" role="presentation"><a role="menuitem" tabindex="-1" href="&#x23;">Disabled link</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another link</a></li>
 </ul></div>

--- a/tests/_files/expected-dropdowns/exemple.phtml
+++ b/tests/_files/expected-dropdowns/exemple.phtml
@@ -1,4 +1,4 @@
-<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
+<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>
 <li role="presentation" class="divider"></li>

--- a/tests/_files/expected-dropdowns/headers.phtml
+++ b/tests/_files/expected-dropdowns/headers.phtml
@@ -1,4 +1,4 @@
-<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul class="dropdown-menu" role="menu"><li role="presentation" class="dropdown-header">Dropdown header</li>
+<div class="clearfix&#x20;dropdown"><a class="sr-only&#x20;dropdown-toggle" data-toggle="dropdown" role="button" href="&#x23;" id="dropdownMenu1">Dropdown <b class="caret"></b></a><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation" class="dropdown-header">Dropdown header</li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>

--- a/tests/_files/expected-input-groups/input-groups-buttons-dropdowns.phtml
+++ b/tests/_files/expected-input-groups/input-groups-buttons-dropdowns.phtml
@@ -1,10 +1,10 @@
-<div class="input-group "><div class="input-group-btn"><button type="button" name="prepend-button" class="btn&#x20;btn-default&#x20;dropdown-toggle" data-toggle="dropdown" value="">Action <b class="caret"></b></button><ul class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
+<div class="input-group "><div class="input-group-btn"><button type="button" name="prepend-button" class="btn&#x20;btn-default&#x20;dropdown-toggle" data-toggle="dropdown" value="">Action <b class="caret"></b></button><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>
 <li role="presentation" class="divider"></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Separated link</a></li>
 </ul></div><input type="text" name="input-username" class="form-control" value=""></div>
-<div class="input-group "><input type="text" name="input-username" class="form-control" value=""><div class="input-group-btn"><button type="button" name="append-button" class="btn&#x20;btn-default&#x20;dropdown-toggle" data-toggle="dropdown" value="">Action <b class="caret"></b></button><ul class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
+<div class="input-group "><input type="text" name="input-username" class="form-control" value=""><div class="input-group-btn"><button type="button" name="append-button" class="btn&#x20;btn-default&#x20;dropdown-toggle" data-toggle="dropdown" value="">Action <b class="caret"></b></button><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>
 <li role="presentation" class="divider"></li>

--- a/tests/_files/expected-input-groups/input-groups-buttons-segmented.phtml
+++ b/tests/_files/expected-input-groups/input-groups-buttons-segmented.phtml
@@ -1,10 +1,10 @@
-<div class="input-group "><div class="input-group-btn"><button type="button" name="prepend-button" class="btn&#x20;btn-default" value="">Action</button><button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown"><span class="caret"></span></button><ul class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
+<div class="input-group "><div class="input-group-btn"><button type="button" name="prepend-button" class="btn&#x20;btn-default" value="">Action</button><button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown"><span class="caret"></span></button><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>
 <li role="presentation" class="divider"></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Separated link</a></li>
 </ul></div><input type="text" name="input-username" class="form-control" value=""></div>
-<div class="input-group "><input type="text" name="input-username" class="form-control" value=""><div class="input-group-btn"><button type="button" name="append-button" class="btn&#x20;btn-default" value="">Action</button><button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown"><span class="caret"></span></button><ul class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
+<div class="input-group "><input type="text" name="input-username" class="form-control" value=""><div class="input-group-btn"><button type="button" name="append-button" class="btn&#x20;btn-default" value="">Action</button><button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown"><span class="caret"></span></button><ul aria-labelledby="dropdownMenu1" class="dropdown-menu" role="menu"><li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Another action</a></li>
 <li role="presentation"><a href="&#x23;" role="menuitem" tabindex="-1">Something else here</a></li>
 <li role="presentation" class="divider"></li>

--- a/tests/_files/expected-input-groups/input-groups-buttons.phtml
+++ b/tests/_files/expected-input-groups/input-groups-buttons.phtml
@@ -1,2 +1,2 @@
-<div class="input-group "><span class="input-group-btn"><button type="button" name="prepend-button" class="btn&#x20;btn-default" value="">Go!</button></span><input type="text" name="input-username" class="form-control" value=""></div>
-<div class="input-group "><input type="text" name="input-username" class="form-control" value=""><span class="input-group-btn"><button type="button" name="append-button" class="btn&#x20;btn-default" value="">Go!</button></span></div>
+<div class="input-group "><div class="input-group-btn"><button type="button" name="prepend-button" class="btn&#x20;btn-default" value="">Go!</button></div><input type="text" name="input-username" class="form-control" value=""></div>
+<div class="input-group "><input type="text" name="input-username" class="form-control" value=""><div class="input-group-btn"><button type="button" name="append-button" class="btn&#x20;btn-default" value="">Go!</button></div></div>


### PR DESCRIPTION
I recently encountered a problem that occurs when rendering button addons with PHP Tidy. 
When button addons are not dropdown they are rendered as spans this then causes PHP Tidy to replace the span inside the button element.

To solve this issue all buttons should be wrapped in a "div" element.