### PR TITLE
Form view helper to not re-apply options the element was initialised with.

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
@@ -106,8 +106,7 @@ class TwbBundleForm extends Form
             }
             // Define layout option to form elements if not already defined
             if ($sFormLayout && empty($aOptions['twb-layout'])) {
-                $aOptions['twb-layout'] = $sFormLayout;
-                $oElement->setOptions($aOptions);
+                $oElement->setOption('twb-layout', $sFormLayout);
             }
 
             // Manage button group option


### PR DESCRIPTION
Hi,

Zend element keeps the options that was used to initialise it. The form view helper takes these and then re-applies them using setOptions() when rendering the form.

This can be a problem when using elements such as \Zend\Form\Element\MultiCheckbox where you can define 'value_options' in the options array, but then use the setter 'setValueOptions' to change the value after the element has been initialised. The value passed via setValueOptions will be discarded by the renderer.

All phpunit tests pass.

Many Thanks