### PR TITLE
Added form-group option for checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ $this->formCheckbox(new \Zend\Form\Element\Checkbox('checkbox-input'));
 ```
 This helper accepts a checkbox element as first param. As the input is rendered into a label element, the label position (append by default) can passed as an option
 The option `disable-twb` (boolean) can be passed to the element to disable rendering it in a `label`.
+The option `form-group` (boolean) can be passed to the element to force the form-group div container.
 
 ```php
 <?php

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -97,7 +97,7 @@ class TwbBundleFormRow extends FormRow
         // Render form row
         switch (true) {
             // Checkbox element not in horizontal form
-            case $sElementType === 'checkbox' && $sLayout !== TwbBundleForm::LAYOUT_HORIZONTAL:
+            case $sElementType === 'checkbox' && $sLayout !== TwbBundleForm::LAYOUT_HORIZONTAL && !$oElement->getOption('form-group'):
             // All "button" elements in inline form
             case in_array($sElementType, array('submit', 'button', 'reset'), true) && $sLayout === TwbBundleForm::LAYOUT_INLINE:
                 return $sElementContent . PHP_EOL;


### PR DESCRIPTION
Override twb-bundle default behavior of not including a form-group div container on a checkbox in the horizontal layout to match bootstrap (http://getbootstrap.com/css/#forms-horizontal)