### PR TITLE
Possibility to use column-size attribute for button groups in Forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,29 @@ Here are the available layouts :
 The helper auto add form specific class and `form` role attributes.
 
 ### Button groups in form
-Form helper can render button groups in a form row, button elements are grouped by the option `button-group`. Exemple :
+Form helper can render button groups in a form row, button elements are grouped by the option `button-group`. Example :
 ```php
 <?php
 $oForm = new \Zend\Form\Form();
 $oForm
     ->add(new \Zend\Form\Element\Button('left-button', array('label' => 'Left', 'button-group' => 'group-1')))
-    ->add(new \Zend\Form\Element\Button('roght-button', array('label' => 'Right', 'button-group' => 'group-1')));
+    ->add(new \Zend\Form\Element\Button('right-button', array('label' => 'Right', 'button-group' => 'group-1')));
 $this->form($oForm);
+```
+
+If any button belonging to a button group has a `column-size` attribute, then the first occurrence of it will be used for the button group styling. Example :
+```php
+<?php
+$oForm = new \Zend\Form\Form();
+$oForm
+    ->add(new \Zend\Form\Element\Button('left-button', array('label' => 'Left', 'button-group' => 'group-1', 'column-size' => 'sm-10 col-sm-offset-2')))
+    ->add(new \Zend\Form\Element\Button('right-button', array('label' => 'Right', 'button-group' => 'group-1')));
+$this->form($oForm);
+```
+This results in following output :
+```html
+<?php
+<div class="form-group "><div class="col-sm-10&#x20;col-sm-offset-2&#x20;btn-group"><button name="left-button" class="btn&#x20;btn-default" value="">Left</button><button name="right-button" class="btn&#x20;btn-default" value="">Right</button></div></div>
 ```
 
 #### Button : `TwbBundle\Form\View\Helper\TwbBundleFormButton`

--- a/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleForm.php
@@ -80,6 +80,9 @@ class TwbBundleForm extends Form
         // Store button groups
         $aButtonGroups = array();
 
+        // Store button groups column-size from buttons
+        $aButtonGroupsColumnSize = array();
+
         // Store elements rendering
         $aElementsRendering = array();
 
@@ -118,6 +121,10 @@ class TwbBundleForm extends Form
                 } else {
                     $aButtonGroups[$sButtonGroupKey] = array($oElement);
                 }
+                if (!empty($aOptions['column-size']) && !isset($aButtonGroupsColumnSize[$sButtonGroupKey])) {
+                    // Only the first occured column-size will be set, other are ignored.
+                    $aButtonGroupsColumnSize[$sButtonGroupKey] = $aOptions['column-size'];
+                }
             } elseif ($oElement instanceof FieldsetInterface) {
                 $aElementsRendering[$iKey] = $oFormCollectionHelper->__invoke($oElement);
             } else {
@@ -133,7 +140,8 @@ class TwbBundleForm extends Form
                 $aButtons = $aButtonGroups[$sElementRendering];
 
                 // Render button group content
-                $sFormContent .= $oFormRowHelper->renderElementFormGroup($oButtonGroupHelper($aButtons), $oFormRowHelper->getRowClassFromElement(current($aButtons)));
+                $options = (isset($aButtonGroupsColumnSize[$sElementRendering])) ? array('attributes' => array('class' => 'col-' . $aButtonGroupsColumnSize[$sElementRendering])) : null;
+                $sFormContent .= $oFormRowHelper->renderElementFormGroup($oButtonGroupHelper($aButtons, $options), $oFormRowHelper->getRowClassFromElement(current($aButtons)));
             } else {
                 $sFormContent .= $sElementRendering;
             }

--- a/tests/TwbBundleTest/BootstrapBasedTests/TwbBundleFormsTest.php
+++ b/tests/TwbBundleTest/BootstrapBasedTests/TwbBundleFormsTest.php
@@ -156,6 +156,52 @@ class TwbBundleFormsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test http://getbootstrap.com/css/#forms-horizontal
+     */
+    public function testHorizontalformButtonGroup()
+    {
+        $oForm = new \Zend\Form\Form();
+        $oForm->add(array(
+            'name' => 'input-email',
+            'attributes' => array(
+                'type' => 'email',
+                'placeholder' => 'Enter email',
+                'id' => 'inputEmail1'
+            ),
+            'options' => array(
+                'label' => 'Email',
+                'column-size' => 'sm-10',
+                'label_attributes' => array('class' => 'col-sm-2')
+            )
+        ))->add(array(
+            'name' => 'input-password',
+            'attributes' => array(
+                'type' => 'password',
+                'placeholder' => 'Password',
+                'id' => 'inputPassword1'
+            ),
+            'options' => array('label' => 'Password', 'column-size' => 'sm-10', 'label_attributes' => array('class' => 'col-sm-2'))
+        ))->add(array(
+            'name' => 'input-checkbox',
+            'type' => 'checkbox',
+            'options' => array('label' => 'Remember me', 'column-size' => 'sm-10 col-sm-offset-2')
+        ))->add(array(
+            'name' => 'button-submit',
+            'type' => 'button',
+            'attributes' => array('type' => 'submit'),
+            'options' => array('label' => 'Sign in', 'column-size' => 'sm-10 col-sm-offset-2', 'button-group' => 'group-1')
+        ))->add(array(
+            'name' => 'button-reset',
+            'type' => 'button',
+            'attributes' => array('type' => 'reset'),
+            'options' => array('label' => 'Reset form', 'column-size' => 'sm-8 col-sm-offset-4', 'button-group' => 'group-1')
+        ));
+
+        //Test content
+        $this->assertStringEqualsFile($this->expectedPath . 'horizontal-form-button-group.phtml', $this->formHelper->__invoke($oForm));
+    }
+
+    /**
      * Test http://getbootstrap.com/css/#forms-controls
      */
     public function testSupportedControlsform()

--- a/tests/_files/expected-forms/horizontal-form-button-group.phtml
+++ b/tests/_files/expected-forms/horizontal-form-button-group.phtml
@@ -1,0 +1,6 @@
+<form method="POST" class="form-horizontal" role="form">
+<div class="form-group "><label class="col-sm-2&#x20;control-label" for="inputEmail1">Email</label><div class=" col-sm-10"><input name="input-email" type="email" placeholder="Enter&#x20;email" id="inputEmail1" class="form-control" value=""></div></div>
+<div class="form-group "><label class="col-sm-2&#x20;control-label" for="inputPassword1">Password</label><div class=" col-sm-10"><input name="input-password" type="password" placeholder="Password" id="inputPassword1" class="form-control" value=""></div></div>
+<div class="form-group "><div class=" col-sm-10 col-sm-offset-2"><div class="checkbox"><input type="hidden" name="input-checkbox" value="0"><label><input type="checkbox" name="input-checkbox" value="1"> Remember me</label></div></div></div>
+<div class="form-group "><div class="col-sm-10&#x20;col-sm-offset-2&#x20;btn-group"><button type="submit" name="button-submit" class="btn&#x20;btn-default" value="">Sign in</button><button type="reset" name="button-reset" class="btn&#x20;btn-default" value="">Reset form</button></div></div>
+</form>


### PR DESCRIPTION
If a button belongs to a button group and has column-size options set, the first found column-size option is used for the button group, so a form file can define beautiful looking button group automatically without any manipulation of form output in the view.