### PR TITLE
add the ability to specify multiple column sizes

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -130,7 +130,7 @@ class TwbBundleFormRow extends FormRow
         if (($sColumSize = $oElement->getOption('column-size')) && $oElement->getOption('twb-layout') !== TwbBundleForm::LAYOUT_HORIZONTAL
         ) {
             $sColumSize = (is_array($sColumSize)) ? $sColumSize : array($sColumSize); 
-            $sRowClass .= implode(' ', array_map(function($item) { return 'col-' . $item; }, $sColumSize));
+            $sRowClass .= implode('', array_map(function($item) { return ' col-' . $item; }, $sColumSize));
         }
 
         //Additional row class

--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -129,7 +129,8 @@ class TwbBundleFormRow extends FormRow
         // Column size
         if (($sColumSize = $oElement->getOption('column-size')) && $oElement->getOption('twb-layout') !== TwbBundleForm::LAYOUT_HORIZONTAL
         ) {
-            $sRowClass .= ' col-' . $sColumSize;
+            $sColumSize = (is_array($sColumSize)) ? $sColumSize : array($sColumSize); 
+            $sRowClass .= implode(' ', array_map(function($item) { return 'col-' . $item; }, $sColumSize));
         }
 
         //Additional row class


### PR DESCRIPTION
It adds the ability to specify multiple column sizes for different size screens. By example: `$element->setOption('column-size', array('lg-3', 'md-6'));`