### PR TITLE
Adding support for has-feedback.

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -103,7 +103,7 @@ class TwbBundleFormRow extends FormRow
                 return $sElementContent . "\n";
             default:
                 // Render element into form group
-                return $this->renderElementFormGroup($sElementContent, $this->getRowClassFromElement($oElement));
+                return $this->renderElementFormGroup($sElementContent, $this->getRowClassFromElement($oElement), $oElement->getOption('feedback'));
         }
     }
 
@@ -125,11 +125,14 @@ class TwbBundleFormRow extends FormRow
         if ($oElement->getMessages()) {
             $sRowClass .= ' has-error';
         }
+        if( $oElement->getOption('feedback')) {
+            $sRowClass .= ' has-feedback';
+        }
 
         // Column size
         if (($sColumSize = $oElement->getOption('column-size')) && $oElement->getOption('twb-layout') !== TwbBundleForm::LAYOUT_HORIZONTAL
         ) {
-            $sColumSize = (is_array($sColumSize)) ? $sColumSize : array($sColumSize); 
+            $sColumSize = (is_array($sColumSize)) ? $sColumSize : array($sColumSize);
             $sRowClass .= implode('', array_map(function($item) { return ' col-' . $item; }, $sColumSize));
         }
 
@@ -143,16 +146,24 @@ class TwbBundleFormRow extends FormRow
     /**
      * @param string $sElementContent
      * @param string $sRowClass
+     * @param string $sFeedbackElement A feedback element that should be rendered within the element, optional
+     *
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function renderElementFormGroup($sElementContent, $sRowClass)
+    public function renderElementFormGroup($sElementContent, $sRowClass, $sFeedbackElement = '' )
     {
         if (!is_string($sElementContent)) {
             throw new \InvalidArgumentException('Argument "$sElementContent" expects a string, "' . (is_object($sElementContent) ? get_class($sElementContent) : gettype($sElementContent)) . '" given');
         }
         if (!is_string($sRowClass)) {
             throw new \InvalidArgumentException('Argument "$sRowClass" expects a string, "' . (is_object($sRowClass) ? get_class($sRowClass) : gettype($sRowClass)) . '" given');
+        }
+        if ($sFeedbackElement && !is_string($sFeedbackElement)) {
+            throw new \InvalidArgumentException('Argument "$sFeedbackElement" expects a string, "' . (is_object($sFeedbackElement) ? get_class($sFeedbackElement) : gettype($sFeedbackElement)) . '" given');
+        }
+        if( $sFeedbackElement ){
+            $sElementContent .= '<i class="' . $sFeedbackElement . ' form-control-feedback"></i>';
         }
         return sprintf(static::$formGroupFormat, $sRowClass, $sElementContent) . "\n";
     }

--- a/tests/TwbBundleTest/Form/View/Helper/TwbBundleFormRowTest.php
+++ b/tests/TwbBundleTest/Form/View/Helper/TwbBundleFormRowTest.php
@@ -186,7 +186,7 @@ class TwbBundleFormRowTest extends \PHPUnit_Framework_TestCase
         // Test content
         $this->assertStringEqualsFile($this->expectedPath . 'input-with-help-text-and-error.phtml', $this->formRowHelper->__invoke($oElement));
     }
-    
+
     public function testRenderWithBothInlineAndNoInlineRadios() {
         $oForm = new \Zend\Form\Form();
         $oForm->add(array(
@@ -205,9 +205,23 @@ class TwbBundleFormRowTest extends \PHPUnit_Framework_TestCase
                 'value_options' => array('label1','label2','label3'),
                 'inline' => false,
             ),
-        ));        
-        
+        ));
+
         $this->assertStringEqualsFile($this->expectedPath . 'both-inline-and-no-inline-radios.phtml', $this->formRowHelper->__invoke($oForm->get('optInput1')).$this->formRowHelper->__invoke($oForm->get('optInput2')));
+    }
+
+    public function testAllowsFeedbackInTextField(){
+        $oForm = new \Zend\Form\Form();
+        $oForm->add(array(
+            'name' => 'username',
+            'type' => 'text',
+            'options' => array(
+                'label' => 'Your Username',
+                'feedback' => 'glyphicon glyphicon-user',
+            ),
+        ));
+
+        $this->assertStringEqualsFile($this->expectedPath . 'has-feedback-in-textfield.phtml', $this->formRowHelper->__invoke($oForm->get('username')));
     }
 
     /**

--- a/tests/_files/expected-rows/has-feedback-in-textfield.phtml
+++ b/tests/_files/expected-rows/has-feedback-in-textfield.phtml
@@ -1,0 +1,1 @@
+<div class="form-group  has-feedback"><label>Your Username</label><input type="text" name="username" class="form-control" value=""><i class="glyphicon glyphicon-user form-control-feedback"></i></div>


### PR DESCRIPTION
Using Bootstrap, one can very simply put glyph icons or font awesome icons into text fields like so:

```
<div class="form-group has-feedback">
    <label class="control-label">Username</label>
    <input type="text" class="form-control" placeholder="Username" />
    <i class="glyphicon glyphicon-user form-control-feedback"></i>
</div>
```

I don't think that this was possible to render with the current build.

This PR addresses this, so that you can easily create the structure above by simply adding this to your element config:

```
    $this->add([
            'name' => 'time_start',
            'type' => Text::class,
            'options' => [
                'label' => _( "Eligible From" ),
                'feedback' => 'glyphicon glyphicon-user',
            ],
        ]);
```

The feedback option, causes the outer wrapper to get the required 'has-feedback' class, and similarly, creates an <i> add on that has the right classes and feedback item.

Thank you very much for considering this PR.
