### PR TITLE
Ability to set the btn-group class

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRadio.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRadio.php
@@ -46,9 +46,15 @@ class TwbBundleFormRadio extends FormRadio
             return $sReturn;
         }
 
-        if (isset($aElementOptions['btn-group']) && $aElementOptions['btn-group'] == true) {
+        if (isset($aElementOptions['btn-group']) && $aElementOptions['btn-group'] != false) {
+
+            $buttonClass = 'btn btn-primary';
+            if (is_array($aElementOptions['btn-group']) && isset($aElementOptions['btn-group']['btn-class'])) {
+                $buttonClass = $aElementOptions['btn-group']['btn-class'];
+            }
+
         	$this->setSeparator('');
-        	$oElement->setLabelAttributes(array('class' => 'btn btn-primary'));
+        	$oElement->setLabelAttributes(array('class' => $buttonClass));
 
         	return sprintf('<div class="btn-group" data-toggle="buttons">%s</div>', parent::render($oElement));
         }


### PR DESCRIPTION
Enhancement of #169 

Instead of only setting it to true

`'btn-group'     => true,`

We'll use this array notation, so we can set the class we want.

`'btn-group'     => [
    'btn-class' => 'btn btn-success',
],`

Before it was fixed in the code. All btn-groups had `btn-primary` class