### PR TITLE
Implement zend component installer support by adding ConfigProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
+        },
+        "zf": {
+            "config-provider": "TwbBundle\\ConfigProvider"
         }
     }
 }

--- a/src/TwbBundle/ConfigProvider.php
+++ b/src/TwbBundle/ConfigProvider.php
@@ -1,0 +1,78 @@
+<?php
+namespace TwbBundle;
+
+/**
+ * The configuration provider for the TwbBundle module
+ *
+ * @see https://docs.zendframework.com/zend-component-installer/
+ */
+class ConfigProvider
+{
+    /**
+     * Path to the module config
+     *
+     * @const string
+     */
+    const MODULE_CONFIG_PATH = __DIR__ . '/../../config/module.config.php';
+
+    /**
+     * The module config ZF2/3
+     *
+     * @var array
+     */
+    protected $moduleConfig;
+
+    /**
+     * Returns the configuration array
+     *
+     * To add a bit of a structure, each section is defined in a separate
+     * method which returns an array with its configuration.
+     *
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public function __invoke()
+    {
+        if (!file_exists(self::MODULE_CONFIG_PATH)) {
+            throw new \InvalidArgumentException('Wrong path to module config file. File or directory does not exist: ' . self::MODULE_CONFIG_PATH);
+        }
+
+        $this->moduleConfig = require self::MODULE_CONFIG_PATH;
+
+        return [
+            'twbbundle' => $this->getTwbBundleOptions(),
+            'dependencies' => $this->getDependencies(),
+            'view_helpers' => $this->getViewHelpers()
+        ];
+    }
+
+    /**
+     * Returns twb bundle options
+     *
+     * @return array
+     */
+    protected function getTwbBundleOptions()
+    {
+        return array_key_exists('twbbundle', $this->moduleConfig) ? $this->moduleConfig['twbbundle'] : [];
+    }
+
+    /**
+     * Returns dependencies (former server_manager)
+     *
+     * @return array
+     */
+    protected function getDependencies()
+    {
+        return array_key_exists('service_manager', $this->moduleConfig) ? $this->moduleConfig['service_manager'] : [];
+    }
+
+    /**
+     * Returns view helpers
+     *
+     * @return array
+     */
+    protected function getViewHelpers()
+    {
+        return array_key_exists('view_helpers', $this->moduleConfig) ? $this->moduleConfig['view_helpers'] : [];
+    }
+}

--- a/tests/TwbBundleTest/ConfigProviderTest.php
+++ b/tests/TwbBundleTest/ConfigProviderTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace TwbBundleTest;
+
+use TwbBundle\ConfigProvider;
+
+/**
+ * Config Provider Test
+ *
+ * @package TwbBundleTest
+ */
+class ConfigProviderTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+     * The zend-component config provider
+     *
+	 * @var \TwbBundle\ConfigProvider
+	 */
+	protected $configProvider;
+
+	/**
+	 * @see \PHPUnit_Framework_TestCase::setUp()
+	 */
+	public function setUp(){
+		$this->configProvider = new ConfigProvider();
+	}
+
+    /**
+     * Tests valid return values
+     */
+	public function testInvokeReturnValues()
+    {
+		$config = $this->configProvider->__invoke();
+
+		$this->assertArrayHasKey('twbbundle', $config);
+        $this->assertArrayHasKey('dependencies', $config);
+        $this->assertArrayHasKey('view_helpers', $config);
+
+        $this->assertNotEmpty($config['twbbundle']);
+        $this->assertNotEmpty($config['dependencies']);
+        $this->assertNotEmpty($config['view_helpers']);
+	}
+}

--- a/tests/TwbBundleTest/ConfigProviderTest.php
+++ b/tests/TwbBundleTest/ConfigProviderTest.php
@@ -12,23 +12,23 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * The zend-component config provider
-     * 
+     *
      * @var \TwbBundle\ConfigProvider
      */
-	protected $configProvider;
+    protected $configProvider;
 
-	/**
-	 * @see \PHPUnit_Framework_TestCase::setUp()
-	 */
-	public function setUp()
+    /**
+     * @see \PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
     {
-		$this->configProvider = new ConfigProvider();
-	}
+        $this->configProvider = new ConfigProvider();
+    }
 
     /**
      * Tests valid return values
      */
-	public function testInvokeReturnValues()
+    public function testInvokeReturnValues()
     {
         $config = $this->configProvider->__invoke();
 

--- a/tests/TwbBundleTest/ConfigProviderTest.php
+++ b/tests/TwbBundleTest/ConfigProviderTest.php
@@ -10,17 +10,18 @@ use TwbBundle\ConfigProvider;
  */
 class ConfigProviderTest extends \PHPUnit_Framework_TestCase
 {
-	/**
+    /**
      * The zend-component config provider
-     *
-	 * @var \TwbBundle\ConfigProvider
-	 */
+     * 
+     * @var \TwbBundle\ConfigProvider
+     */
 	protected $configProvider;
 
 	/**
 	 * @see \PHPUnit_Framework_TestCase::setUp()
 	 */
-	public function setUp(){
+	public function setUp()
+    {
 		$this->configProvider = new ConfigProvider();
 	}
 
@@ -29,14 +30,14 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
      */
 	public function testInvokeReturnValues()
     {
-		$config = $this->configProvider->__invoke();
+        $config = $this->configProvider->__invoke();
 
-		$this->assertArrayHasKey('twbbundle', $config);
+        $this->assertArrayHasKey('twbbundle', $config);
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertArrayHasKey('view_helpers', $config);
 
         $this->assertNotEmpty($config['twbbundle']);
         $this->assertNotEmpty($config['dependencies']);
         $this->assertNotEmpty($config['view_helpers']);
-	}
+    }
 }


### PR DESCRIPTION
This PR adds the zend-component-installer config provider support. Used for example in zend-expressive.
When there is a valid ConfigProvider in the module the zend-component-installer automatically detects the module on composer install and ask you if you want to add module/component to your application. (zf -> config-provider entry in composer.json)

A config-provider is for use with applications that utilize expressive-config-manager or zend-config-aggregator (which may or may not be Expressive applications)

zend-component-installer: [https://docs.zendframework.com/zend-component-installer/](https://docs.zendframework.com/zend-component-installer/) 

Zend blog: [https://framework.zend.com/blog/2017-04-20-config-aggregator.html](https://framework.zend.com/blog/2017-04-20-config-aggregator.html) 