### PR TITLE
Fixed bug regarding error validation state of checkboxes

### DIFF
--- a/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
+++ b/src/TwbBundle/Form/View/Helper/TwbBundleFormRow.php
@@ -218,7 +218,7 @@ class TwbBundleFormRow extends FormRow
                 if ($oElement->getOption('validation-state') || $oElement->getMessages()) {
                     if (empty($aLabelAttributes['class'])) {
                         $aLabelAttributes['class'] = 'control-label';
-                    } elseif (!preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class'])) {
+                    } elseif (!preg_match('/(\s|^)control-label(\s|$)/', $aLabelAttributes['class']) && $sElementType !== 'checkbox') {
                         $aLabelAttributes['class'] = trim($aLabelAttributes['class'] . ' control-label');
                     }
                 }


### PR DESCRIPTION
Problem:
The class `control-label` is added to labels of checkboxes when they are erroneous. This is not documented in bootstraps documentation / examples (https://getbootstrap.com/docs/3.3/css/?#forms-control-validation) and leads to design issues (see Screenshot).
![bildschirmfoto 2018-04-27 um 11 04 49](https://user-images.githubusercontent.com/12804757/39355525-be69e07e-4a0d-11e8-8d2e-b75032bd47f1.png)

Solution:
Adding check for element type => if element is `checkbox`, skip adding `control-label` class.
![bildschirmfoto 2018-04-27 um 11 18 20](https://user-images.githubusercontent.com/12804757/39355531-c3581498-4a0d-11e8-8f34-45bbcb536692.png)