### PR TITLE
Fix formElement's config

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -21,6 +21,15 @@ return array(
         ),
     ),
     'view_helpers' => array (
+        'aliases' => array (
+            'form_element' => 'TwbBundle\Form\View\Helper\TwbBundleFormElement',
+            'formElement' => 'TwbBundle\Form\View\Helper\TwbBundleFormElement',
+            'formelement' => 'TwbBundle\Form\View\Helper\TwbBundleFormElement',
+
+            'navigation'   => 'TwbBundle\View\Helper\Navigation',
+            'Navigation'   => 'TwbBundle\View\Helper\Navigation',
+            'zendviewhelpernavigation'   => 'TwbBundle\View\Helper\Navigation',
+        ),
         'invokables' => array (
             //Alert
             'alert' => 'TwbBundle\View\Helper\TwbBundleAlert',
@@ -98,18 +107,8 @@ return array(
             'formhidden'   => 'Zend\Form\View\Helper\FormHidden',
         ),
         'factories' => array (
-            'formElement' => 'TwbBundle\Form\View\Helper\Factory\TwbBundleFormElementFactory',
-            'form_element' => 'TwbBundle\Form\View\Helper\Factory\TwbBundleFormElementFactory',
-            'formelement' => 'TwbBundle\Form\View\Helper\Factory\TwbBundleFormElementFactory',
             'TwbBundle\Form\View\Helper\TwbBundleFormElement' => 'TwbBundle\Form\View\Helper\Factory\TwbBundleFormElementFactory',
-
-            'navigation'                => 'TwbBundle\Navigation\View\NavigationHelperFactory',
-            'zendviewhelpernavigation'  => 'TwbBundle\Navigation\View\NavigationHelperFactory',
-        ),
-        'aliases' => array (
-            'form_element' => 'TwbBundle\Form\View\Helper\TwbBundleFormElement',
-
-            'Navigation'   => 'TwbBundle\Navigation\View\NavigationHelperFactory',
+            'TwbBundle\View\Helper\Navigation' => 'TwbBundle\Navigation\View\NavigationHelperFactory',
         ),
     ),
 );

--- a/tests/TwbBundleTest/ConfigProviderTest.php
+++ b/tests/TwbBundleTest/ConfigProviderTest.php
@@ -40,4 +40,12 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($config['dependencies']);
         $this->assertNotEmpty($config['view_helpers']);
     }
+
+    public function testFormElementRegression()
+    {
+        $config = $this->configProvider->__invoke();
+        $this->assertArrayHasKey('formElement', $config['view_helpers']['aliases']);
+    }
+
+
 }


### PR DESCRIPTION
This PR fixes the container configuration for `TwbBundle\Form\View\Helper\TwbBundleFormElement` and `TwbBundle\View\Helper\Navigation`.

From what I understand, aliases are processed before factories, so when merging the configuration of all ZF modules, the 'aliases/formElement' entry in zend-form takes precedence and the factory entry 'factories/formElement' is ignored.

In order to override the zend-form's element, we need to create an alias with that name.

See https://github.com/neilime/zf2-twb-bundle/issues/203